### PR TITLE
Don't set a default fontSize for links

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -62,7 +62,6 @@ Link.propTypes = {
 };
 
 Link.defaultProps = {
-  fontSize: 'size2',
   variant: 'default'
 };
 

--- a/stories/links.stories.js
+++ b/stories/links.stories.js
@@ -7,10 +7,16 @@ const stories = storiesOf('Links', module);
 
 stories.add('default', () => (
   <Box m="regular">
-    <Link m="regular" href="#test" onClick={e => e.preventDefault()}>
+    <Link
+      fontSize="size2"
+      m="regular"
+      href="#test"
+      onClick={e => e.preventDefault()}
+    >
       Default Link
     </Link>
     <Link
+      fontSize="size2"
       m="regular"
       variant="muted"
       href="#test"

--- a/tests/__snapshots__/Link.test.js.snap
+++ b/tests/__snapshots__/Link.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<Link /> Variants properly renders a default Link 1`] = `
 .emotion-0 {
-  font-size: 0.875rem;
   font-family: Motiva Sans;
   line-height: 1.5;
   -webkit-text-decoration: none;
@@ -37,7 +36,6 @@ exports[`<Link /> Variants properly renders a default Link 1`] = `
 
 <a
   className="emotion-0 emotion-1"
-  fontSize="size2"
   href="#test"
 >
   Link
@@ -46,7 +44,6 @@ exports[`<Link /> Variants properly renders a default Link 1`] = `
 
 exports[`<Link /> Variants properly renders a muted Link 1`] = `
 .emotion-0 {
-  font-size: 0.875rem;
   font-family: Motiva Sans;
   line-height: 1.5;
   -webkit-text-decoration: none;
@@ -81,7 +78,6 @@ exports[`<Link /> Variants properly renders a muted Link 1`] = `
 
 <a
   className="emotion-0 emotion-1"
-  fontSize="size2"
   href="#test"
 >
   Link


### PR DESCRIPTION
Setting a default fontSize lead to a weird interface when actually used.
For example, if you stuck a Link inside of a Paragraph with variant
'tiny', the link would be much bigger than the rest of the text. You
could fix this by setting fontSize to inherit on the Link but this felt
like an antipattern.