### PR TITLE
Remove webkit appearance from inputs

### DIFF
--- a/src/reset.js
+++ b/src/reset.js
@@ -130,4 +130,7 @@ export default css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+  input {
+    appearance: none;
+  }
 `;


### PR DESCRIPTION
iOS webkit appearance applies a shadow that we do not want as part of
the UIKit.

[#162599799]