### PR TITLE
Update prefix for font icons

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -129,7 +129,7 @@ export default {
   colors,
   fontWeights,
   fontSizes,
-  iconFontPrefix: 'fa',
+  iconFontPrefix: 'ar',
   lineHeights,
   space: spacings,
   typography

--- a/tests/__snapshots__/Button.test.js.snap
+++ b/tests/__snapshots__/Button.test.js.snap
@@ -67,7 +67,7 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 1`] 
     Button with Icon
   </span>
   <i
-    className="fa fa-cr-logo emotion-2 emotion-3"
+    className="ar ar-cr-logo emotion-2 emotion-3"
   />
 </button>
 `;
@@ -139,7 +139,7 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 2`] 
     Button with Icon
   </span>
   <i
-    className="fa fa-cr-logo emotion-2 emotion-3"
+    className="ar ar-cr-logo emotion-2 emotion-3"
   />
 </button>
 `;
@@ -211,7 +211,7 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 3`] 
     Button with Icon
   </span>
   <i
-    className="fa fa-cr-logo emotion-2 emotion-3"
+    className="ar ar-cr-logo emotion-2 emotion-3"
   />
 </button>
 `;
@@ -283,7 +283,7 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 4`] 
     Button with Icon
   </span>
   <i
-    className="fa fa-cr-logo emotion-2 emotion-3"
+    className="ar ar-cr-logo emotion-2 emotion-3"
   />
 </button>
 `;
@@ -348,7 +348,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   size="small"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -358,7 +358,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
     Button with Icon
   </span>
   <i
-    className="fa fa-download emotion-0 emotion-1"
+    className="ar ar-download emotion-0 emotion-1"
   />
 </button>
 `;
@@ -423,7 +423,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   size="medium"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -433,7 +433,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
     Button with Icon
   </span>
   <i
-    className="fa fa-download emotion-0 emotion-1"
+    className="ar ar-download emotion-0 emotion-1"
   />
 </button>
 `;
@@ -498,7 +498,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   size="large"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -508,7 +508,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
     Button with Icon
   </span>
   <i
-    className="fa fa-download emotion-0 emotion-1"
+    className="ar ar-download emotion-0 emotion-1"
   />
 </button>
 `;
@@ -573,7 +573,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   size="jumbo"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -583,7 +583,7 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
     Button with Icon
   </span>
   <i
-    className="fa fa-download emotion-0 emotion-1"
+    className="ar ar-download emotion-0 emotion-1"
   />
 </button>
 `;
@@ -648,7 +648,7 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   size="small"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -720,7 +720,7 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   size="medium"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -792,7 +792,7 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   size="large"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"
@@ -864,7 +864,7 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   size="jumbo"
 >
   <i
-    className="fa fa-cr-logo emotion-0 emotion-1"
+    className="ar ar-cr-logo emotion-0 emotion-1"
   />
   <span
     className="emotion-2 emotion-3"

--- a/tests/__snapshots__/CardActions.test.js.snap
+++ b/tests/__snapshots__/CardActions.test.js.snap
@@ -12,10 +12,10 @@ exports[`<CardActions renders the CardActions component properly 1`] = `
   className="emotion-4 emotion-5"
 >
   <i
-    className="fa fa-download emotion-0 emotion-1"
+    className="ar ar-download emotion-0 emotion-1"
   />
   <i
-    className="fa fa-chat-bubble-outline emotion-0 emotion-1"
+    className="ar ar-chat-bubble-outline emotion-0 emotion-1"
   />
 </div>
 `;

--- a/tests/__snapshots__/Checkbox.test.js.snap
+++ b/tests/__snapshots__/Checkbox.test.js.snap
@@ -171,7 +171,7 @@ exports[`<Checkbox /> properly renders a checkbox with an icon 1`] = `
     disabled={false}
   />
   <i
-    className="fa fa-cr-logo emotion-4 emotion-5"
+    className="ar ar-cr-logo emotion-4 emotion-5"
     color="grey50"
     fontSize="24px"
   />
@@ -270,7 +270,7 @@ exports[`<Checkbox /> properly renders a checked and indeterminate checkbox 1`] 
     disabled={false}
   >
     <i
-      className="fa fa-checkbox-indeterminate emotion-2 emotion-3"
+      className="ar ar-checkbox-indeterminate emotion-2 emotion-3"
       fontSize="16px"
     />
   </div>
@@ -369,7 +369,7 @@ exports[`<Checkbox /> properly renders a checked checkbox 1`] = `
     disabled={false}
   >
     <i
-      className="fa fa-checkbox-checked emotion-2 emotion-3"
+      className="ar ar-checkbox-checked emotion-2 emotion-3"
       fontSize="16px"
     />
   </div>
@@ -558,7 +558,7 @@ exports[`<Checkbox /> properly renders a disabled indeterminate checkbox 1`] = `
     disabled={true}
   >
     <i
-      className="fa fa-checkbox-indeterminate emotion-2 emotion-3"
+      className="ar ar-checkbox-indeterminate emotion-2 emotion-3"
       fontSize="16px"
     />
   </div>
@@ -654,7 +654,7 @@ exports[`<Checkbox /> properly renders an indeterminate checkbox 1`] = `
     disabled={false}
   >
     <i
-      className="fa fa-checkbox-indeterminate emotion-2 emotion-3"
+      className="ar ar-checkbox-indeterminate emotion-2 emotion-3"
       fontSize="16px"
     />
   </div>

--- a/tests/__snapshots__/Icon.test.js.snap
+++ b/tests/__snapshots__/Icon.test.js.snap
@@ -14,7 +14,7 @@ exports[`<Icon /> applies a class of just the icon font prefix 1`] = `
 
 exports[`<Icon /> renders an icon properly 1`] = `
 <i
-  className="fa fa-my-icon css-ui3h2r-StyledIcon emotion-0"
+  className="ar ar-my-icon css-ui3h2r-StyledIcon emotion-0"
 />
 `;
 
@@ -26,7 +26,7 @@ exports[`<Icon /> supports 90 degree rotation 1`] = `
 }
 
 <i
-  className="fa fa-my-icon emotion-0 emotion-1"
+  className="ar ar-my-icon emotion-0 emotion-1"
 />
 `;
 
@@ -38,7 +38,7 @@ exports[`<Icon /> supports 180 degree rotation 1`] = `
 }
 
 <i
-  className="fa fa-my-icon emotion-0 emotion-1"
+  className="ar ar-my-icon emotion-0 emotion-1"
 />
 `;
 
@@ -50,6 +50,6 @@ exports[`<Icon /> supports 270 degree rotation 1`] = `
 }
 
 <i
-  className="fa fa-my-icon emotion-0 emotion-1"
+  className="ar ar-my-icon emotion-0 emotion-1"
 />
 `;

--- a/tests/__snapshots__/MenuItem.test.js.snap
+++ b/tests/__snapshots__/MenuItem.test.js.snap
@@ -69,7 +69,7 @@ exports[`<MenuItem /> renders a MenuItem properly 1`] = `
     value="ready_to_clear"
   />
   <i
-    className="fa fa-status emotion-0 emotion-1"
+    className="ar ar-status emotion-0 emotion-1"
     color="grey"
     fontSize="16px"
   />
@@ -154,7 +154,7 @@ exports[`<MenuItem /> renders a selected MenuItem properly 1`] = `
     value="ready_to_clear"
   />
   <i
-    className="fa fa-status emotion-0 emotion-1"
+    className="ar ar-status emotion-0 emotion-1"
     color="grey"
     fontSize="16px"
   />

--- a/tests/__snapshots__/Tooltip.test.js.snap
+++ b/tests/__snapshots__/Tooltip.test.js.snap
@@ -69,7 +69,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
           "medium": 600,
           "regular": 400,
         },
-        "iconFontPrefix": "fa",
+        "iconFontPrefix": "ar",
         "lineHeights": Object {
           "large": 1.5,
           "small": 1.25,
@@ -231,7 +231,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
                 "medium": 600,
                 "regular": 400,
               },
-              "iconFontPrefix": "fa",
+              "iconFontPrefix": "ar",
               "lineHeights": Object {
                 "large": 1.5,
                 "small": 1.25,


### PR DESCRIPTION
[#161004112]

* Update icon prefix to ar instead of fa to prevent conflicts with
existing icon font

Co-authored-by: Damian Galarza <damian@catchandrelease.com>