### PR TITLE
 Add propTypes support to createWithComponent 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
         ]
       }
     ],
+    'react/forbid-foreign-prop-types': false,
     'arbor/use-create-with-component': 'error'
   },
   overrides: [

--- a/rules/index.js
+++ b/rules/index.js
@@ -7,7 +7,7 @@ module.exports.rules = {
     },
 
     'ExpressionStatement AssignmentExpression Identifier': node => {
-      if (node.name === 'defaultProps') {
+      if (node.name === 'defaultProps' || node.name === 'propTypes') {
         const source = context.getSourceCode();
         const name = node.parent.object && node.parent.object.name;
 
@@ -34,7 +34,9 @@ module.exports.rules = {
         if (usedCreateWithComponent) {
           context.report(
             node,
-            'Pass defaultProps as argument of createWithComponent utility method'
+            `Pass ${
+              node.name
+            } via the options argument of createWithComponent utility method`
           );
         }
       }

--- a/rules/package.json
+++ b/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-arbor",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "devDependencies": {
     "eslint": "^5.6.1"

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -5,7 +5,9 @@ import createWithComponent from '../utils/createWithComponent';
 
 const Card = styled(
   createWithComponent(Box, 'div', {
-    boxShadow: 'elevation0'
+    defaultProps: {
+      boxShadow: 'elevation0'
+    }
   })
 )`
   border-radius: ${props => props.theme.borderRadius.large};

--- a/src/CardActions/CardActions.js
+++ b/src/CardActions/CardActions.js
@@ -10,7 +10,9 @@ const gridStyles = ({ children }) => css`
 
 const CardActions = styled(
   createWithComponent(Grid, 'div', {
-    gridGap: 'smaller'
+    defaultProps: {
+      gridGap: 'smaller'
+    }
   })
 )`
   ${gridStyles};

--- a/src/CardPreview/CardPreview.js
+++ b/src/CardPreview/CardPreview.js
@@ -9,6 +9,10 @@ const CardPreview = styled(
   createWithComponent(Box, 'div', {
     defaultProps: {
       ratio: 9 / 16
+    },
+    propTypes: {
+      image: PropTypes.string.isRequired,
+      ...ratio.propTypes
     }
   })
 )`
@@ -17,10 +21,5 @@ const CardPreview = styled(
   background-size: contain;
   ${ratio};
 `;
-
-CardPreview.propTypes = {
-  image: PropTypes.string.isRequired,
-  ...ratio.propType
-};
 
 export default CardPreview;

--- a/src/CardPreview/CardPreview.js
+++ b/src/CardPreview/CardPreview.js
@@ -7,7 +7,9 @@ import createWithComponent from '../utils/createWithComponent';
 
 const CardPreview = styled(
   createWithComponent(Box, 'div', {
-    ratio: 9 / 16
+    defaultProps: {
+      ratio: 9 / 16
+    }
   })
 )`
   background: url(${props => props.image}) center center no-repeat

--- a/src/CardRow/CardRow.js
+++ b/src/CardRow/CardRow.js
@@ -2,11 +2,13 @@ import createWithComponent from '../utils/createWithComponent';
 import Flex from '../Flex';
 
 const CardRow = createWithComponent(Flex, 'div', {
-  px: 'regular',
-  py: 'smallest',
-  my: 'smaller',
-  alignItems: 'center',
-  justifyContent: 'space-between'
+  defaultProps: {
+    px: 'regular',
+    py: 'smallest',
+    my: 'smaller',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  }
 });
 
 export default CardRow;

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -9,18 +9,20 @@ import {
 import Box from '../Box';
 import createWithComponent from '../utils/createWithComponent';
 
-const Grid = styled(createWithComponent(Box, 'div'))`
+const Grid = styled(
+  createWithComponent(Box, 'div', {
+    propTypes: {
+      ...gridGap.propTypes,
+      ...gridTemplateColumns.propTypes,
+      ...justifyItems.propTypes
+    }
+  })
+)`
   display: grid;
   ${alignItems};
   ${gridGap};
   ${gridTemplateColumns};
   ${justifyItems};
 `;
-
-Grid.propTypes = {
-  ...gridGap.propTypes,
-  ...gridTemplateColumns.propTypes,
-  ...justifyItems.propTypes
-};
 
 export default Grid;

--- a/src/Heading/Heading.js
+++ b/src/Heading/Heading.js
@@ -18,8 +18,10 @@ const calculatedMargin = ({ mb, fontSize, theme }) =>
 
 const Heading = styled(
   createWithComponent(Text, 'h1', {
-    color: 'text.dark',
-    fontWeight: 'bold'
+    defaultProps: {
+      color: 'text.dark',
+      fontWeight: 'bold'
+    }
   })
 )`
   ${baseStyles};
@@ -27,25 +29,35 @@ const Heading = styled(
 `;
 
 Heading.h1 = createWithComponent(Heading, 'h1', {
-  fontSize: 'size7'
+  defaultProps: {
+    fontSize: 'size7'
+  }
 });
 
 Heading.h2 = createWithComponent(Heading, 'h2', {
-  fontSize: 'size6'
+  defaultProps: {
+    fontSize: 'size6'
+  }
 });
 
 Heading.h3 = createWithComponent(Heading, 'h3', {
-  fontSize: 'size5'
+  defaultProps: {
+    fontSize: 'size5'
+  }
 });
 
 Heading.h4 = createWithComponent(Heading, 'h4', {
-  fontSize: 'size4'
+  defaultProps: {
+    fontSize: 'size4'
+  }
 });
 
 Heading.h5 = styled(
   createWithComponent(Heading, 'h5', {
-    fontSize: 'size4',
-    fontWeight: 'medium'
+    defaultProps: {
+      fontSize: 'size4',
+      fontWeight: 'medium'
+    }
   })
 )`
   line-height: ${props => props.theme.lineHeights.large};
@@ -53,8 +65,10 @@ Heading.h5 = styled(
 
 Heading.h6 = styled(
   createWithComponent(Heading, 'h6', {
-    fontSize: 'size4',
-    fontWeight: 'regular'
+    defaultProps: {
+      fontSize: 'size4',
+      fontWeight: 'regular'
+    }
   })
 )`
   line-height: ${props => props.theme.lineHeights.large};

--- a/src/Link/Link.js
+++ b/src/Link/Link.js
@@ -64,6 +64,9 @@ const Link = styled(
   createWithComponent(Text, 'a', {
     defaultProps: {
       variant: 'default'
+    },
+    propTypes: {
+      variant: PropTypes.oneOf(['default', 'muted'])
     }
   })
 )`
@@ -71,9 +74,5 @@ const Link = styled(
   ${variantStyles};
   ${color};
 `;
-
-Link.propTypes = {
-  variant: PropTypes.oneOf(['default', 'muted'])
-};
 
 export default Link;

--- a/src/Link/Link.js
+++ b/src/Link/Link.js
@@ -62,7 +62,9 @@ const variantStyles = ({ variant, theme: { colors } }) => {
 
 const Link = styled(
   createWithComponent(Text, 'a', {
-    variant: 'default'
+    defaultProps: {
+      variant: 'default'
+    }
   })
 )`
   ${baseStyles};

--- a/src/utils/__tests__/createWithComponent.test.js
+++ b/src/utils/__tests__/createWithComponent.test.js
@@ -2,42 +2,71 @@ import Box from '../../Box';
 import createWithComponent from '../createWithComponent';
 
 describe('createWithComponent', () => {
+  const createComponent = options => Object.assign(Box, options);
+
   it('returns a component with default props from the source component', () => {
-    const srcComponent = Box;
-    srcComponent.defaultProps = { foo: 'bar' };
+    const srcComponent = createComponent({ defaultProps: { foo: 'bar' } });
 
     const component = createWithComponent(srcComponent, 'header');
 
     expect(component.defaultProps.foo).toEqual('bar');
   });
 
-  context('with defaultProps argument', () => {
-    it('assigns the default props to the new component', () => {
-      const defaultProps = { baz: 'qux' };
-      const srcComponent = Box;
-      srcComponent.defaultProps = { foo: 'bar' };
+  it('returns a component with prop types from the source component', () => {
+    const srcComponent = createComponent({ propTypes: { foo: 'bar' } });
 
-      const component = createWithComponent(
-        srcComponent,
-        'header',
-        defaultProps
-      );
+    const component = createWithComponent(srcComponent, 'header');
 
-      expect(component.defaultProps.baz).toEqual('qux');
+    expect(component.propTypes.foo).toEqual('bar'); // eslint-disable-line react/forbid-foreign-prop-types
+  });
+
+  context('with options argument', () => {
+    context('defaultProps', () => {
+      it('assigns the default props to the new component', () => {
+        const srcComponent = createComponent({ defaultProps: { foo: 'bar' } });
+        const defaultProps = { baz: 'qux' };
+
+        const component = createWithComponent(srcComponent, 'header', {
+          defaultProps
+        });
+
+        expect(component.defaultProps.baz).toEqual('qux');
+      });
+
+      it('overwrites source component default props with passed default props', () => {
+        const srcComponent = createComponent({ defaultProps: { foo: 'bar' } });
+        const defaultProps = { foo: 'baz' };
+
+        const component = createWithComponent(srcComponent, 'header', {
+          defaultProps
+        });
+
+        expect(component.defaultProps.foo).toEqual('baz');
+      });
     });
 
-    it('overwrites source component default props with passed default props', () => {
-      const defaultProps = { foo: 'baz' };
-      const srcComponent = Box;
-      srcComponent.defaultProps = { foo: 'bar' };
+    context('propTypes', () => {
+      it('assigns the propTypes to the new component', () => {
+        const srcComponent = createComponent({ propTypes: { foo: 'bar' } });
+        const propTypes = { baz: 'qux' };
 
-      const component = createWithComponent(
-        srcComponent,
-        'header',
-        defaultProps
-      );
+        const component = createWithComponent(srcComponent, 'header', {
+          propTypes
+        });
 
-      expect(component.defaultProps.foo).toEqual('baz');
+        expect(component.propTypes.baz).toEqual('qux'); // eslint-disable-line react/forbid-foreign-prop-types
+      });
+
+      it('overwrites source component prop types with passed default props', () => {
+        const srcComponent = createComponent({ propTypes: { foo: 'bar' } });
+        const propTypes = { foo: 'baz' };
+
+        const component = createWithComponent(srcComponent, 'header', {
+          propTypes
+        });
+
+        expect(component.propTypes.foo).toEqual('baz'); // eslint-disable-line react/forbid-foreign-prop-types
+      });
     });
   });
 });

--- a/src/utils/__tests__/createWithComponent.test.js
+++ b/src/utils/__tests__/createWithComponent.test.js
@@ -17,7 +17,7 @@ describe('createWithComponent', () => {
 
     const component = createWithComponent(srcComponent, 'header');
 
-    expect(component.propTypes.foo).toEqual('bar'); // eslint-disable-line react/forbid-foreign-prop-types
+    expect(component.propTypes.foo).toEqual('bar');
   });
 
   context('with options argument', () => {
@@ -54,7 +54,7 @@ describe('createWithComponent', () => {
           propTypes
         });
 
-        expect(component.propTypes.baz).toEqual('qux'); // eslint-disable-line react/forbid-foreign-prop-types
+        expect(component.propTypes.baz).toEqual('qux');
       });
 
       it('overwrites source component prop types with passed default props', () => {
@@ -65,7 +65,7 @@ describe('createWithComponent', () => {
           propTypes
         });
 
-        expect(component.propTypes.foo).toEqual('baz'); // eslint-disable-line react/forbid-foreign-prop-types
+        expect(component.propTypes.foo).toEqual('baz');
       });
     });
   });

--- a/src/utils/createWithComponent.js
+++ b/src/utils/createWithComponent.js
@@ -1,9 +1,18 @@
-const withComponent = (srcComponent, destComponent, defaultProps) => {
+const withComponent = (
+  srcComponent,
+  destComponent,
+  { defaultProps, propTypes } = {}
+) => {
   const component = srcComponent.withComponent(destComponent); // eslint-disable-line arbor/use-create-with-component
 
   component.defaultProps = {
     ...srcComponent.defaultProps,
     ...defaultProps
+  };
+
+  component.propTypes = {
+    ...srcComponent.propTypes,
+    ...propTypes
   };
 
   return component;


### PR DESCRIPTION
[#164253604]

* Add rule for propTypes via creatWithComponent 
* Update createWithComponent to support passing propTypes as an option
* Conform previous createWithComponent calls to using the new options
argument
* Conform to new linting rule for propTypes when using the
createWithComponent utility