### PR TITLE
Handle case where minimal button isn't last-child

### DIFF
--- a/src/Accordion/StyledAccordionHeader.js
+++ b/src/Accordion/StyledAccordionHeader.js
@@ -11,8 +11,12 @@ const StyledHeader = styled(createWithComponent(Flex, 'header'))`
     border-bottom: none;
   }
 
-  .button--minimal:last-child {
+  .button--minimal:last-of-type {
     margin-right: -${props => props.theme.space.small};
+
+    + :not(object) {
+      margin-left: ${props => props.theme.space.small};
+    }
   }
 
   button + .button--secondary,

--- a/src/Accordion/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/Accordion/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -24,8 +24,12 @@ section:last-child .emotion-6 {
   border-bottom: none;
 }
 
-.emotion-6 .button--minimal:last-child {
+.emotion-6 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -129,8 +133,12 @@ section:last-child .emotion-8 {
   border-bottom: none;
 }
 
-.emotion-8 .button--minimal:last-child {
+.emotion-8 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-8 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-8 button + .button--secondary,
@@ -248,8 +256,12 @@ section:last-child .emotion-6 {
   border-bottom: none;
 }
 
-.emotion-6 .button--minimal:last-child {
+.emotion-6 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -353,8 +365,12 @@ section:last-child .emotion-6 {
   border-bottom: none;
 }
 
-.emotion-6 .button--minimal:last-child {
+.emotion-6 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-6 button + .button--secondary,

--- a/src/Accordion/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/Accordion/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -24,8 +24,12 @@ section:last-child .emotion-6 {
   border-bottom: none;
 }
 
-.emotion-6 .button--minimal:last-child {
+.emotion-6 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -152,8 +156,12 @@ section:last-child .emotion-6 {
   border-bottom: none;
 }
 
-.emotion-6 .button--minimal:last-child {
+.emotion-6 .button--minimal:last-of-type {
   margin-right: -0.75rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.75rem;
 }
 
 .emotion-6 button + .button--secondary,


### PR DESCRIPTION
We ran into a case where the minimal button may not be the exact last
child that we needed to account for. This was specific to working with
popovers since the library injected an object into the DOM next to the
trigger, causing the button to jump around.