### PR TITLE
Properly accept theme in GlobalStyles

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -6,12 +6,11 @@ import PropTypes from 'prop-types';
 import 'react-tippy/dist/tippy.css';
 import { Tooltip as TippyTooltip } from 'react-tippy';
 
-import { borderRadius } from '../theme';
 import Text from '../Text';
 
-const globalTippyStyles = css`
+const globalTippyStyles = theme => css`
   .tippy-tooltip.arbor-theme {
-    border-radius: ${borderRadius.small};
+    border-radius: ${theme.borderRadius.small};
     padding: 0;
   }
 `;

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -157,14 +157,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
     }
   >
     <ForwardRef(render)
-      styles={
-        Object {
-          "map": undefined,
-          "name": "957k5c-globalTippyStyles",
-          "next": undefined,
-          "styles": ".tippy-tooltip.arbor-theme{border-radius:3px;padding:0;}label:globalTippyStyles;",
-        }
-      }
+      styles={[Function]}
     >
       <InnerGlobal
         cache={


### PR DESCRIPTION
It appears that in the latest version of emotion, the `style` prop now
works in the same manner as the updated `css` prop which takes in the
theme. This means we no longer need to import the borderRadius manually
to set the global styles for tooltips.