### PR TITLE
Extract Pane component

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -1,18 +1,10 @@
-import styled from '@emotion/styled';
-
-import Box from '../Box';
+import Pane from '../Pane';
 import createWithComponent from '../utils/createWithComponent';
 
-const Card = styled(
-  createWithComponent(Box, 'div', {
-    defaultProps: {
-      borderRadius: 'large',
-      boxShadow: 'elevation0'
-    }
-  })
-)`
-  border: 1px solid ${props => props.theme.colors.border.default};
-  width: 100%;
-`;
+const Card = createWithComponent(Pane, 'div', {
+  defaultProps: {
+    borderRadius: 'large'
+  }
+});
 
 export default Card;

--- a/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -5,7 +5,8 @@ exports[`<Card /> renders a Card properly 1`] = `
   box-sizing: border-box;
   border-radius: 6px;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);
-  border: 1px solid #E0E1E2;
+  background-color: #FFFFFF;
+  display: grid;
   width: 100%;
 }
 

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled';
 import {
+  alignContent,
   alignItems,
+  gridColumnGap,
   gridGap,
+  gridRowGap,
   gridTemplateColumns,
+  justifyContent,
   justifyItems
 } from 'styled-system';
 
@@ -12,16 +16,24 @@ import createWithComponent from '../utils/createWithComponent';
 const Grid = styled(
   createWithComponent(Box, 'div', {
     propTypes: {
+      ...alignContent.propTypes,
+      ...gridColumnGap.propTypes,
       ...gridGap.propTypes,
       ...gridTemplateColumns.propTypes,
+      ...gridRowGap.propTypes,
+      ...justifyContent.propTypes,
       ...justifyItems.propTypes
     }
   })
 )`
   display: grid;
+  ${alignContent};
   ${alignItems};
+  ${gridColumnGap};
   ${gridGap};
+  ${gridRowGap};
   ${gridTemplateColumns};
+  ${justifyContent};
   ${justifyItems};
 `;
 

--- a/src/Pane/Pane.js
+++ b/src/Pane/Pane.js
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+
+import Grid from '../Grid';
+import { createWithComponent } from '../utils';
+
+const Pane = styled(
+  createWithComponent(Grid, 'div', {
+    defaultProps: {
+      bg: 'background.white',
+      boxShadow: 'elevation0'
+    }
+  })
+)`
+  width: 100%;
+`;
+
+export default Pane;

--- a/src/Pane/index.js
+++ b/src/Pane/index.js
@@ -1,0 +1,1 @@
+export { default } from './Pane';

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -11,6 +11,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
         "backgroundColors": Object {
           "default": "#F2F2F2",
           "muted": "#F8F9F9",
+          "white": "#FFFFFF",
         },
         "borderColors": Object {
           "default": "#E0E1E2",
@@ -38,6 +39,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
           "background": Object {
             "default": "#F2F2F2",
             "muted": "#F8F9F9",
+            "white": "#FFFFFF",
           },
           "black": "#000000",
           "blue": "#4466EE",
@@ -220,6 +222,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
               "backgroundColors": Object {
                 "default": "#F2F2F2",
                 "muted": "#F8F9F9",
+                "white": "#FFFFFF",
               },
               "borderColors": Object {
                 "default": "#E0E1E2",
@@ -247,6 +250,7 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
                 "background": Object {
                   "default": "#F2F2F2",
                   "muted": "#F8F9F9",
+                  "white": "#FFFFFF",
                 },
                 "black": "#000000",
                 "blue": "#4466EE",

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export { default as Label } from './Label';
 export { default as Link } from './Link';
 export { default as Menu } from './Menu';
 export { default as Pagination } from './Pagination';
+export { default as Pane } from './Pane';
 export { default as Paragraph } from './Paragraph';
 export { default as Popover } from './Popover';
 export { default as Header } from './Header';

--- a/src/theme.js
+++ b/src/theme.js
@@ -51,7 +51,8 @@ export const bronzes = {
 
 export const backgroundColors = {
   muted: greys.grey10,
-  default: greys.grey20
+  default: greys.grey20,
+  white: whites.white
 };
 
 export const borderColors = {

--- a/stories/card-and-pane.stories.js
+++ b/stories/card-and-pane.stories.js
@@ -1,0 +1,72 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import { storiesOf } from '@storybook/react';
+
+import { createWithComponent } from '../src/utils';
+import { Box, Card, Grid, Heading, Paragraph, Text } from '../src';
+
+const stories = storiesOf('Cards', module);
+
+const ExampleCard = createWithComponent(Card, 'div', {
+  defaultProps: {
+    height: '160px',
+    alignContent: 'center',
+    justifyContent: 'center'
+  }
+});
+
+const Description = createWithComponent(Text, 'p', {
+  defaultProps: {
+    fontSize: 'size1',
+    textAlign: 'center'
+  }
+});
+
+stories.add('default', () => (
+  <Grid
+    m="regular"
+    mt="largest"
+    gridTemplateColumns="repeat(5, 200px)"
+    gridColumnGap="40px"
+    gridRowGap="20px"
+    justifyContent="center"
+  >
+    <Box
+      css={css`
+        grid-column: 1/-1;
+      `}
+    >
+      <Heading.h2>Cards</Heading.h2>
+      <Paragraph variant="ui">
+        Cards compose pane with a default border-radius provided.
+      </Paragraph>
+    </Box>
+
+    <ExampleCard>
+      <Heading.h6>Card / Elevation 0</Heading.h6>
+      <Description>Flat Cards</Description>
+    </ExampleCard>
+
+    <ExampleCard boxShadow="elevation1">
+      <Heading.h6>Card / Elevation 1</Heading.h6>
+      <Description>Floating Cards</Description>
+    </ExampleCard>
+
+    <ExampleCard boxShadow="elevation2">
+      <Heading.h6>Card / Elevation 2</Heading.h6>
+      <Description>Top Bar</Description>
+    </ExampleCard>
+
+    <ExampleCard boxShadow="elevation3">
+      <Heading.h6>Card / Elevation 3</Heading.h6>
+      <Description>Side Sheet</Description>
+    </ExampleCard>
+
+    <ExampleCard boxShadow="elevation4">
+      <Heading.h6>Card / Elevation 4</Heading.h6>
+      <Description>Unused</Description>
+    </ExampleCard>
+  </Grid>
+));
+
+export default stories;

--- a/stories/pane.stories.js
+++ b/stories/pane.stories.js
@@ -1,0 +1,65 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+import { storiesOf } from '@storybook/react';
+
+import { createWithComponent } from '../src/utils';
+import { Grid, Heading, Pane, Text } from '../src';
+
+const ExamplePane = createWithComponent(Pane, 'div', {
+  defaultProps: {
+    height: '160px',
+    alignContent: 'center',
+    justifyContent: 'center'
+  }
+});
+
+const Description = createWithComponent(Text, 'p', {
+  defaultProps: {
+    fontSize: 'size1',
+    textAlign: 'center'
+  }
+});
+
+const stories = storiesOf('Panes', module);
+
+stories.add('defaul', () => (
+  <Grid
+    m="regular"
+    mt="largest"
+    gridTemplateColumns="repeat(5, 200px)"
+    gridColumnGap="40px"
+    justifyContent="center"
+  >
+    <Heading.h2
+      css={css`
+        grid-column: 1/-1;
+      `}
+    >
+      Panes
+    </Heading.h2>
+    <ExamplePane>
+      <Heading.h6>Pane / Elevation 0</Heading.h6>
+      <Description>Flat Panes</Description>
+    </ExamplePane>
+
+    <ExamplePane boxShadow="elevation1">
+      <Heading.h6>Pane / Elevation 1</Heading.h6>
+      <Description>Floating Panes</Description>
+    </ExamplePane>
+
+    <ExamplePane boxShadow="elevation2">
+      <Heading.h6>Pane / Elevation 2</Heading.h6>
+      <Description>Top Bar</Description>
+    </ExamplePane>
+
+    <ExamplePane boxShadow="elevation3">
+      <Heading.h6>Pane / Elevation 3</Heading.h6>
+      <Description>Side Sheet</Description>
+    </ExamplePane>
+
+    <ExamplePane boxShadow="elevation4">
+      <Heading.h6>Pane / Elevation 4</Heading.h6>
+      <Description>Unused</Description>
+    </ExamplePane>
+  </Grid>
+));

--- a/stories/shot-card.stories.js
+++ b/stories/shot-card.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import stories from './card-and-pane.stories';
 
 import {
   Box,
@@ -15,8 +15,6 @@ import {
   Link,
   Tooltip
 } from '../src';
-
-const stories = storiesOf('Cards', module);
 
 const exampleCards = [
   {
@@ -55,7 +53,7 @@ const like = (
   <Icon color="icons.default" fontSize="24" name="thumb-up-outline" />
 );
 
-stories.add('Card', () => (
+stories.add('Shot Card Example', () => (
   <Box m="regular">
     <Heading.h2>Cards</Heading.h2>
 


### PR DESCRIPTION
A pane requires a background and a boxShadow. Both have defaults provided.

* Card composes Pane with a borderRadius set.
* Add white as a background color
* Popover content doens't need to specify a borderRadius since card already has one.

![image](https://user-images.githubusercontent.com/105694/53916100-4eba8d00-402f-11e9-81b0-409deffa579e.png)
