### PR TITLE
Specify node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "license": "MIT",
   "repository": "git@github.com:CatchRelease/arbor.git",
+  "engines": {
+    "node": "~8"
+  },
   "dependencies": {
     "@emotion/core": "^10.0.0",
     "@emotion/styled": "^10.0.0",


### PR DESCRIPTION
As part of this I removed the setup command `nvm install node` from codeship. By default, codeship will install a version of node based on the engines node of the package.json.