### PR TITLE
Make accordion header styles a bit more generic

### DIFF
--- a/src/AccordionSection/AccordionHeader.js
+++ b/src/AccordionSection/AccordionHeader.js
@@ -4,26 +4,22 @@ import PropTypes from 'prop-types';
 import StyledAccordionHeader from './StyledAccordionHeader';
 import StyledAccordionHeading from './StyledAccordionHeading';
 import StyledAccordionHeadingButton from './StyledAccordionHeadingButton';
-import Text from '../Text';
 import Icon from '../Icon';
 
 const AccordionHeaderIcon = ({ isOpen }) => (
-  <Icon ml="regular" mr="small" name="caret" rotation={isOpen ? null : '270'} />
+  <Icon mr="small" name="caret" rotation={isOpen ? null : '270'} />
 );
 
 AccordionHeaderIcon.propTypes = {
   isOpen: PropTypes.bool.isRequired
 };
 
-const AccordionHeaderNote = ({ note }) =>
-  note && (
-    <Text mr="regular" fontSize="size4" textAlign="right" color="text.muted">
-      {note}
-    </Text>
-  );
-
 const AccordionHeader = ({ isOpen, note, onClick, panelId, text }) => (
-  <StyledAccordionHeader alignItems="center" justifyContent="space-between">
+  <StyledAccordionHeader
+    alignItems="center"
+    justifyContent="space-between"
+    px="regular"
+  >
     <StyledAccordionHeading fontWeight="medium" mr="regular">
       <StyledAccordionHeadingButton
         alignItems="center"
@@ -36,7 +32,7 @@ const AccordionHeader = ({ isOpen, note, onClick, panelId, text }) => (
         {text}
       </StyledAccordionHeadingButton>
     </StyledAccordionHeading>
-    <AccordionHeaderNote note={note} />
+    {note}
   </StyledAccordionHeader>
 );
 

--- a/src/AccordionSection/AccordionHeader.js
+++ b/src/AccordionSection/AccordionHeader.js
@@ -8,7 +8,7 @@ import Text from '../Text';
 import Icon from '../Icon';
 
 const AccordionHeaderIcon = ({ isOpen }) => (
-  <Icon mr="small" name="caret" rotation={isOpen ? null : '270'} />
+  <Icon ml="regular" mr="small" name="caret" rotation={isOpen ? null : '270'} />
 );
 
 AccordionHeaderIcon.propTypes = {
@@ -17,17 +17,13 @@ AccordionHeaderIcon.propTypes = {
 
 const AccordionHeaderNote = ({ note }) =>
   note && (
-    <Text fontSize="size4" textAlign="right" color="text.muted">
+    <Text mr="regular" fontSize="size4" textAlign="right" color="text.muted">
       {note}
     </Text>
   );
 
 const AccordionHeader = ({ isOpen, note, onClick, panelId, text }) => (
-  <StyledAccordionHeader
-    alignItems="center"
-    justifyContent="space-between"
-    p="regular"
-  >
+  <StyledAccordionHeader alignItems="center" justifyContent="space-between">
     <StyledAccordionHeading fontWeight="medium" mr="regular">
       <StyledAccordionHeadingButton
         alignItems="center"

--- a/src/AccordionSection/StyledAccordionHeader.js
+++ b/src/AccordionSection/StyledAccordionHeader.js
@@ -12,10 +12,10 @@ const StyledHeader = styled(createWithComponent(Flex, 'header'))`
   }
 
   .button--minimal:last-of-type {
-    margin-right: -${props => props.theme.space.smaller};
+    margin-right: -${props => props.theme.space.smallest};
 
     + :not(object) {
-      margin-left: ${props => props.theme.space.smaller};
+      margin-left: ${props => props.theme.space.smallest};
     }
   }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -3,7 +3,6 @@
 exports[`<AccordionHeader /> properly renders an accordion header 1`] = `
 .emotion-6 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25,11 +24,11 @@ section:last-child .emotion-6 {
 }
 
 .emotion-6 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-6 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -78,6 +77,7 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -112,7 +112,6 @@ section:last-child .emotion-6 {
 exports[`<AccordionHeader /> renders with a note 1`] = `
 .emotion-8 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,11 +133,11 @@ section:last-child .emotion-8 {
 }
 
 .emotion-8 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-8 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-8 button + .button--secondary,
@@ -187,6 +186,7 @@ section:last-child .emotion-8 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -197,6 +197,7 @@ section:last-child .emotion-8 {
   font-family: Motiva Sans;
   color: #5B5D61;
   font-size: 0.875rem;
+  margin-right: 1rem;
   text-align: right;
 }
 
@@ -235,7 +236,6 @@ section:last-child .emotion-8 {
 exports[`<AccordionHeader /> renders with an on click 1`] = `
 .emotion-6 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -257,11 +257,11 @@ section:last-child .emotion-6 {
 }
 
 .emotion-6 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-6 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -310,6 +310,7 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -344,7 +345,6 @@ section:last-child .emotion-6 {
 exports[`<AccordionHeader /> renders with the panel visible 1`] = `
 .emotion-6 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -366,11 +366,11 @@ section:last-child .emotion-6 {
 }
 
 .emotion-6 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-6 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -419,6 +419,7 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
 }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -3,6 +3,8 @@
 exports[`<AccordionHeader /> properly renders an accordion header 1`] = `
 .emotion-6 {
   box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,7 +79,6 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
-  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -110,132 +111,10 @@ section:last-child .emotion-6 {
 `;
 
 exports[`<AccordionHeader /> renders with a note 1`] = `
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  background: #F2F2F2;
-  border-bottom: 1px solid #E0E1E2;
-}
-
-section:last-child .emotion-8 {
-  border-bottom: none;
-}
-
-.emotion-8 .button--minimal:last-of-type {
-  margin-right: -0.25rem;
-}
-
-.emotion-8 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.25rem;
-}
-
-.emotion-8 button + .button--secondary,
-.emotion-8 button + .button--primary {
-  margin-left: 0.5rem;
-}
-
-.emotion-4 {
-  font-family: Motiva Sans;
-  color: #0F0F10;
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-right: 1rem;
-  line-height: 1.25;
-  margin-bottom: calc(0.875rem * 0.5);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: inherit;
-  padding: 0;
-}
-
-.emotion-0 {
-  margin-left: 1rem;
-  margin-right: 0.75rem;
-  -webkit-transform: rotate(270deg);
-  -ms-transform: rotate(270deg);
-  transform: rotate(270deg);
-}
-
-.emotion-6 {
-  font-family: Motiva Sans;
-  color: #5B5D61;
-  font-size: 0.875rem;
-  margin-right: 1rem;
-  text-align: right;
-}
-
-<header
-  className="emotion-8 emotion-9"
->
-  <h1
-    className="emotion-4 emotion-5"
-    color="text.dark"
-    fontSize="size4"
-    fontWeight="medium"
-  >
-    <button
-      aria-controls="my-accordion-1"
-      aria-expanded={false}
-      className="emotion-2 emotion-3"
-      onClick={[Function]}
-      type="button"
-    >
-      <i
-        className="ar ar-caret emotion-0 emotion-1"
-      />
-      My Heading
-    </button>
-  </h1>
-  <p
-    className="emotion-6 emotion-7"
-    color="text.muted"
-    fontSize="size4"
-  >
-    My Accordion Section Note
-  </p>
-</header>
-`;
-
-exports[`<AccordionHeader /> renders with an on click 1`] = `
 .emotion-6 {
   box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,7 +189,117 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
-  margin-left: 1rem;
+  margin-right: 0.75rem;
+  -webkit-transform: rotate(270deg);
+  -ms-transform: rotate(270deg);
+  transform: rotate(270deg);
+}
+
+<header
+  className="emotion-6 emotion-7"
+>
+  <h1
+    className="emotion-4 emotion-5"
+    color="text.dark"
+    fontSize="size4"
+    fontWeight="medium"
+  >
+    <button
+      aria-controls="my-accordion-1"
+      aria-expanded={false}
+      className="emotion-2 emotion-3"
+      onClick={[Function]}
+      type="button"
+    >
+      <i
+        className="ar ar-caret emotion-0 emotion-1"
+      />
+      My Heading
+    </button>
+  </h1>
+  My Accordion Section Note
+</header>
+`;
+
+exports[`<AccordionHeader /> renders with an on click 1`] = `
+.emotion-6 {
+  box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  background: #F2F2F2;
+  border-bottom: 1px solid #E0E1E2;
+}
+
+section:last-child .emotion-6 {
+  border-bottom: none;
+}
+
+.emotion-6 .button--minimal:last-of-type {
+  margin-right: -0.25rem;
+}
+
+.emotion-6 .button--minimal:last-of-type +:not(object) {
+  margin-left: 0.25rem;
+}
+
+.emotion-6 button + .button--secondary,
+.emotion-6 button + .button--primary {
+  margin-left: 0.5rem;
+}
+
+.emotion-4 {
+  font-family: Motiva Sans;
+  color: #0F0F10;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-right: 1rem;
+  line-height: 1.25;
+  margin-bottom: calc(0.875rem * 0.5);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+}
+
+.emotion-0 {
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -345,6 +334,8 @@ section:last-child .emotion-6 {
 exports[`<AccordionHeader /> renders with the panel visible 1`] = `
 .emotion-6 {
   box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -419,7 +410,6 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
-  margin-left: 1rem;
   margin-right: 0.75rem;
 }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -3,6 +3,8 @@
 exports[`<AccordionSection /> render accordion is closed renders with the panel hidden 1`] = `
 .emotion-6 {
   box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,7 +79,6 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
-  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -134,6 +135,8 @@ section:last-child .emotion-8 {
 exports[`<AccordionSection /> render accordion is open renders with the panel visible 1`] = `
 .emotion-6 {
   box-sizing: border-box;
+  padding-left: 1rem;
+  padding-right: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -208,7 +211,6 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
-  margin-left: 1rem;
   margin-right: 0.75rem;
 }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -3,7 +3,6 @@
 exports[`<AccordionSection /> render accordion is closed renders with the panel hidden 1`] = `
 .emotion-6 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25,11 +24,11 @@ section:last-child .emotion-6 {
 }
 
 .emotion-6 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-6 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -78,6 +77,7 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
@@ -134,7 +134,6 @@ section:last-child .emotion-8 {
 exports[`<AccordionSection /> render accordion is open renders with the panel visible 1`] = `
 .emotion-6 {
   box-sizing: border-box;
-  padding: 1rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -156,11 +155,11 @@ section:last-child .emotion-6 {
 }
 
 .emotion-6 .button--minimal:last-of-type {
-  margin-right: -0.5rem;
+  margin-right: -0.25rem;
 }
 
 .emotion-6 .button--minimal:last-of-type +:not(object) {
-  margin-left: 0.5rem;
+  margin-left: 0.25rem;
 }
 
 .emotion-6 button + .button--secondary,
@@ -209,6 +208,7 @@ section:last-child .emotion-6 {
 }
 
 .emotion-0 {
+  margin-left: 1rem;
   margin-right: 0.75rem;
 }
 

--- a/stories/accordion.stories.js
+++ b/stories/accordion.stories.js
@@ -74,6 +74,12 @@ stories.add('default', () => {
     </Box>
   );
 
+  const note = (
+    <Text fontSize="size4" textAlign="right" color="text.muted">
+      With Note
+    </Text>
+  );
+
   return (
     <>
       <AccordionContainer>
@@ -83,7 +89,7 @@ stories.add('default', () => {
           <Card>
             <AccordionSection
               header={<Box my="small">Header 1: Controlled</Box>}
-              headerNote="With Note"
+              headerNote={note}
               isOpen={boolean('isOpen', isOpen)}
               onHeaderClick={onHeaderClick}
               panelId="header-1-controlled"
@@ -105,7 +111,7 @@ stories.add('default', () => {
             </AccordionSection>
             <AccordionSection
               header={<Box my="small">Header 2: Uncontrolled </Box>}
-              headerNote="Note"
+              headerNote={note}
               panelId="header-2-uncontrolled"
             >
               <Pane p="regular">

--- a/stories/accordion.stories.js
+++ b/stories/accordion.stories.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { forceReRender, storiesOf } from '@storybook/react';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 
 import {
   AccordionSection,
+  Box,
   Button,
   Card,
   Flex,
@@ -22,39 +23,16 @@ const onHeaderClick = () => {
   forceReRender();
 };
 
+const buttonOptions = {
+  Small: 'small',
+  Medium: 'medium',
+  Large: 'large',
+  Jumbo: 'jumbo'
+};
+const defaultButtonSize = 'small';
+
 const trashIcon = <Icon name="trash" />;
 const annotationIcon = <Icon name="annotation" />;
-const noteWithButtons = (
-  <>
-    <Button variant="minimal" size="small" iconStart={annotationIcon}>
-      Message
-    </Button>
-    <Button variant="minimal" size="small" iconStart={trashIcon} />
-  </>
-);
-
-const noteWithPrimaryButtons = (
-  <>
-    <Button variant="secondary" size="small">
-      Secondary
-    </Button>
-    <Button variant="primary" size="small">
-      Primary
-    </Button>
-  </>
-);
-
-const noteWithSecondaryButtons = (
-  <>
-    <Button variant="minimal" size="small">
-      Minimal
-    </Button>
-    <Button variant="secondary" size="small">
-      Secondary
-    </Button>
-  </>
-);
-
 const AccordionContainer = Flex.withComponent('div'); // eslint-disable-line arbor/use-create-with-component
 AccordionContainer.defaultProps = {
   mt: '100px',
@@ -62,166 +40,201 @@ AccordionContainer.defaultProps = {
   alignItems: 'center'
 };
 
-stories.add('default', () => (
-  <>
-    <AccordionContainer>
-      <Heading.h2>Accordion</Heading.h2>
+stories.add('default', () => {
+  const sizeSelect = select('Size', buttonOptions, defaultButtonSize);
 
-      <Flex justifyContent="center" width="500px">
-        <Card>
-          <AccordionSection
-            header="Header 1: Controlled"
-            headerNote="With Note"
-            isOpen={boolean('isOpen', isOpen)}
-            onHeaderClick={onHeaderClick}
-            panelId="header-1-controlled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">
-                You can manually control an accordion by using isOpen and
-                onHeaderClick together.
-              </Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-          <AccordionSection
-            header="Header 2: Uncontrolled"
-            headerNote="Note"
-            panelId="header-2-uncontrolled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">
-                If you exclude the isOpen property, the accordion state will be
-                automattically managed internally
-              </Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-          <AccordionSection
-            header="Header 3: Uncontrolled"
-            panelId="header-3-uncontrolled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">You can exclude the note property</Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-        </Card>
-      </Flex>
-    </AccordionContainer>
+  const noteWithButtons = (
+    <Box my="smallest">
+      <Button variant="minimal" size={sizeSelect} iconStart={annotationIcon}>
+        Message
+      </Button>
+      <Button variant="minimal" size={sizeSelect} iconStart={trashIcon} />
+    </Box>
+  );
 
-    <AccordionContainer>
-      <Heading.h2>Accordion with minimal buttons in notes</Heading.h2>
+  const noteWithPrimaryButtons = (
+    <Box my="smallest">
+      <Button variant="secondary" size={sizeSelect}>
+        Secondary
+      </Button>
+      <Button variant="primary" size={sizeSelect}>
+        Primary
+      </Button>
+    </Box>
+  );
 
-      <Flex justifyContent="center" width="500px">
-        <Card>
-          <AccordionSection
-            header="Header 1: Controlled"
-            headerNote={noteWithButtons}
-            isOpen={boolean('isOpen', isOpen)}
-            onHeaderClick={onHeaderClick}
-            panelId="header-1-controlled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">
-                You can manually control an accordion by using isOpen and
-                onHeaderClick together.
-              </Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-        </Card>
-      </Flex>
-    </AccordionContainer>
+  const noteWithSecondaryButtons = (
+    <Box my="smallest">
+      <Button variant="minimal" size={sizeSelect}>
+        Minimal
+      </Button>
+      <Button variant="secondary" size={sizeSelect}>
+        Secondary
+      </Button>
+    </Box>
+  );
 
-    <AccordionContainer>
-      <Heading.h2>Accordion with primary buttons</Heading.h2>
+  return (
+    <>
+      <AccordionContainer>
+        <Heading.h2>Accordion</Heading.h2>
 
-      <Flex justifyContent="center" width="500px">
-        <Card>
-          <AccordionSection
-            header="Header 1: Controlled"
-            headerNote={noteWithPrimaryButtons}
-            isOpen={boolean('isOpen', isOpen)}
-            onHeaderClick={onHeaderClick}
-            panelId="header-1-controlled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">
-                You can manually control an accordion by using isOpen and
-                onHeaderClick together.
-              </Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-        </Card>
-      </Flex>
-    </AccordionContainer>
+        <Flex justifyContent="center" width="500px">
+          <Card>
+            <AccordionSection
+              header={<Box my="small">Header 1: Controlled</Box>}
+              headerNote="With Note"
+              isOpen={boolean('isOpen', isOpen)}
+              onHeaderClick={onHeaderClick}
+              panelId="header-1-controlled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">
+                  You can manually control an accordion by using isOpen and
+                  onHeaderClick together.
+                </Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+            <AccordionSection
+              header={<Box my="small">Header 2: Uncontrolled </Box>}
+              headerNote="Note"
+              panelId="header-2-uncontrolled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">
+                  If you exclude the isOpen property, the accordion state will
+                  be automattically managed internally
+                </Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+            <AccordionSection
+              header={<Box my="small">Header 3: Uncontrolled</Box>}
+              panelId="header-3-uncontrolled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">You can exclude the note property</Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+          </Card>
+        </Flex>
+      </AccordionContainer>
 
-    <AccordionContainer>
-      <Heading.h2>Accordion with secondary buttons</Heading.h2>
+      <AccordionContainer>
+        <Heading.h2>Accordion with minimal buttons in notes</Heading.h2>
 
-      <Flex justifyContent="center" width="500px">
-        <Card>
-          <AccordionSection
-            header="Header 1: Controlled"
-            headerNote={noteWithSecondaryButtons}
-            isOpen={boolean('isOpen', isOpen)}
-            onHeaderClick={onHeaderClick}
-            panelId="header-1-controlled"
-          >
-            <Pane p="regular">
-              <Text mb="regular">
-                You can manually control an accordion by using isOpen and
-                onHeaderClick together.
-              </Text>
-              <Text>
-                Lorem ipsum dolor sit amet, an hinc honestatis his, an his tota
-                aperiam intellegebat. Mel delenit delectus et, veniam soleat
-                pericula vix et. Aeque accumsan quo ex, albucius pericula
-                expetendis quo ei. Debitis oporteat at eos, mei justo eruditi
-                periculis te. Sed no mazim liber dicunt, aeque viris animal te
-                quo, ius lorem feugiat veritus id.
-              </Text>
-            </Pane>
-          </AccordionSection>
-        </Card>
-      </Flex>
-    </AccordionContainer>
-  </>
-));
+        <Flex justifyContent="center" width="500px">
+          <Card>
+            <AccordionSection
+              header={<Box my="small">Header 1: Controlled</Box>}
+              headerNote={noteWithButtons}
+              isOpen={boolean('isOpen', isOpen)}
+              onHeaderClick={onHeaderClick}
+              panelId="header-1-controlled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">
+                  You can manually control an accordion by using isOpen and
+                  onHeaderClick together.
+                </Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+          </Card>
+        </Flex>
+      </AccordionContainer>
+
+      <AccordionContainer>
+        <Heading.h2>Accordion with primary buttons</Heading.h2>
+
+        <Flex justifyContent="center" width="500px">
+          <Card>
+            <AccordionSection
+              header={<Box my="small">Header 1: Controlled</Box>}
+              headerNote={noteWithPrimaryButtons}
+              isOpen={boolean('isOpen', isOpen)}
+              onHeaderClick={onHeaderClick}
+              panelId="header-1-controlled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">
+                  You can manually control an accordion by using isOpen and
+                  onHeaderClick together.
+                </Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+          </Card>
+        </Flex>
+      </AccordionContainer>
+
+      <AccordionContainer>
+        <Heading.h2>Accordion with secondary buttons</Heading.h2>
+
+        <Flex justifyContent="center" width="500px">
+          <Card>
+            <AccordionSection
+              header={<Box my="small">Header 1: Controlled</Box>}
+              headerNote={noteWithSecondaryButtons}
+              isOpen={boolean('isOpen', isOpen)}
+              onHeaderClick={onHeaderClick}
+              panelId="header-1-controlled"
+            >
+              <Pane p="regular">
+                <Text mb="regular">
+                  You can manually control an accordion by using isOpen and
+                  onHeaderClick together.
+                </Text>
+                <Text>
+                  Lorem ipsum dolor sit amet, an hinc honestatis his, an his
+                  tota aperiam intellegebat. Mel delenit delectus et, veniam
+                  soleat pericula vix et. Aeque accumsan quo ex, albucius
+                  pericula expetendis quo ei. Debitis oporteat at eos, mei justo
+                  eruditi periculis te. Sed no mazim liber dicunt, aeque viris
+                  animal te quo, ius lorem feugiat veritus id.
+                </Text>
+              </Pane>
+            </AccordionSection>
+          </Card>
+        </Flex>
+      </AccordionContainer>
+    </>
+  );
+});


### PR DESCRIPTION
We're still imposing to many styles on Accordion header. This strips out
some of the default spacing that we're using, IE: padding on the inside
of the header. Instead, a user should compose a component like Box to
add custom spacing.

[#164291096]