### PR TITLE
bump node engine in package.js to be based on 10, the latest LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": "git@github.com:CatchRelease/arbor.git",
   "engines": {
-    "node": "~8"
+    "node": "~10"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",


### PR DESCRIPTION
https://github.com/facebook/jest/issues/8069
https://github.com/nodejs/node/pull/26488

:point_up: those are current blockers on node 11