### PR TITLE
Specify node engine compatible with C&R

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": "git@github.com:CatchRelease/arbor.git",
   "engines": {
-    "node": "~10"
+    "node": ">=8.0.0 <11.11.0"
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",


### PR DESCRIPTION
We're still using 8.x on the C&R app. We can't install this package
right now with the engine set to 10.