### PR TITLE
Prevent extra props from getting to button text

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -20,9 +20,7 @@ const Button = React.forwardRef(
     >
       {iconStart}
       {children && (
-        <ButtonText {...{ iconStart, iconEnd, ...props }}>
-          {children}
-        </ButtonText>
+        <ButtonText {...{ iconStart, iconEnd }}>{children}</ButtonText>
       )}
       {iconEnd}
     </StyledButton>

--- a/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -60,8 +60,6 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 1`] 
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="small"
   >
     Button with Icon
   </span>
@@ -131,8 +129,6 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 2`] 
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="medium"
   >
     Button with Icon
   </span>
@@ -202,8 +198,6 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 3`] 
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Button with Icon
   </span>
@@ -273,8 +267,6 @@ exports[`<Button /> Sizes iconEnd properly renders a button with an iconEnd 4`] 
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="jumbo"
   >
     Button with Icon
   </span>
@@ -347,8 +339,6 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="small"
   >
     Button with Icon
   </span>
@@ -421,8 +411,6 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="medium"
   >
     Button with Icon
   </span>
@@ -495,8 +483,6 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="large"
   >
     Button with Icon
   </span>
@@ -569,8 +555,6 @@ exports[`<Button /> Sizes iconStart and iconEnd properly renders a button with a
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="jumbo"
   >
     Button with Icon
   </span>
@@ -643,8 +627,6 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="small"
   >
     Button with Icon
   </span>
@@ -714,8 +696,6 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="medium"
   >
     Button with Icon
   </span>
@@ -785,8 +765,6 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="large"
   >
     Button with Icon
   </span>
@@ -856,8 +834,6 @@ exports[`<Button /> Sizes iconStart properly renders a button with an iconStart 
   />
   <span
     className="emotion-2 emotion-3"
-    disabled={false}
-    size="jumbo"
   >
     Button with Icon
   </span>
@@ -924,8 +900,6 @@ exports[`<Button /> Sizes properly renders a jumbo sized button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="jumbo"
   >
     Button Label
   </span>
@@ -992,8 +966,6 @@ exports[`<Button /> Sizes properly renders a large sized button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Button Label
   </span>
@@ -1060,8 +1032,6 @@ exports[`<Button /> Sizes properly renders a medium sized button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="medium"
   >
     Button Label
   </span>
@@ -1128,8 +1098,6 @@ exports[`<Button /> Sizes properly renders a small sized button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="small"
   >
     Button Label
   </span>
@@ -1204,8 +1172,6 @@ exports[`<Button /> Variants properly renders a disabled minimal button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={true}
-    size="large"
   >
     Button Label
   </span>
@@ -1272,8 +1238,6 @@ exports[`<Button /> Variants properly renders a disabled primary button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={true}
-    size="large"
   >
     Button Label
   </span>
@@ -1350,8 +1314,6 @@ exports[`<Button /> Variants properly renders a disabled secondary button 1`] = 
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={true}
-    size="large"
   >
     Button Label
   </span>
@@ -1426,8 +1388,6 @@ exports[`<Button /> Variants properly renders a minimal button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Button Label
   </span>
@@ -1494,8 +1454,6 @@ exports[`<Button /> Variants properly renders a primary button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Button Label
   </span>
@@ -1572,8 +1530,6 @@ exports[`<Button /> Variants properly renders a secondary button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Button Label
   </span>
@@ -1641,8 +1597,6 @@ exports[`<Button /> fullWidth properly renders a fullWidth button 1`] = `
 >
   <span
     className="emotion-0 emotion-1"
-    disabled={false}
-    size="large"
   >
     Full Width
   </span>

--- a/src/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -91,8 +91,6 @@ exports[`<Header /> renders with heading and a button 1`] = `
   >
     <span
       className="emotion-2 emotion-3"
-      disabled={false}
-      size="large"
     >
       Primary
     </span>
@@ -282,8 +280,6 @@ exports[`<Header /> renders with heaeding and multiple buttons 1`] = `
   >
     <span
       className="emotion-2 emotion-3"
-      disabled={false}
-      size="large"
     >
       Secondary
     </span>
@@ -295,8 +291,6 @@ exports[`<Header /> renders with heaeding and multiple buttons 1`] = `
   >
     <span
       className="emotion-2 emotion-3"
-      disabled={false}
-      size="large"
     >
       Primary
     </span>


### PR DESCRIPTION
[#165102829]

* We were passing all props from the button down to the button text.
This can result in unwanted behavior like onClicks getting duplicated.
Instead lets only pass what is needed.