### PR TITLE
Hide overflow by default on accordion panels

### DIFF
--- a/src/AccordionSection/StyledAccordionPanel.js
+++ b/src/AccordionSection/StyledAccordionPanel.js
@@ -9,4 +9,8 @@ const StyledAccordionPanel = styled(Box)`
   }
 `;
 
+StyledAccordionPanel.defaultProps = {
+  overflow: 'hidden'
+};
+
 export default StyledAccordionPanel;

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -89,6 +89,7 @@ section:last-child .emotion-7 {
   box-sizing: border-box;
   border-bottom: 1px solid #E0E1E2;
   display: none;
+  overflow: hidden;
 }
 
 section:last-child .emotion-9 {
@@ -124,6 +125,7 @@ section:last-child .emotion-9 {
     className="emotion-9 emotion-10"
     display="none"
     id="my-accordion-1"
+    overflow="hidden"
   >
     <p>
       Hello World
@@ -218,6 +220,7 @@ section:last-child .emotion-7 {
   box-sizing: border-box;
   border-bottom: 1px solid #E0E1E2;
   display: block;
+  overflow: hidden;
 }
 
 section:last-child .emotion-9 {
@@ -253,6 +256,7 @@ section:last-child .emotion-9 {
     className="emotion-9 emotion-10"
     display="block"
     id="my-accordion-1"
+    overflow="hidden"
   >
     <p>
       Hello World


### PR DESCRIPTION
[Finishes #165069678]

* Overflow is already exposed to the accordion panel via Box. Setting
the default Prop for overflow to be hidden allows us to overwrite it if
need be.