### PR TITLE
Move grid display definition to defaultProp

### DIFF
--- a/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -6,13 +6,14 @@ exports[`<Card /> renders a Card properly 1`] = `
   border-radius: 6px;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);
   background-color: #FFFFFF;
+  display: grid;
   overflow: hidden;
   width: 100%;
-  display: grid;
 }
 
 <div
   className="emotion-0 emotion-1"
+  display="grid"
   overflow="hidden"
   width="100%"
 />

--- a/src/CardActions/__tests__/__snapshots__/CarActions.test.js.snap
+++ b/src/CardActions/__tests__/__snapshots__/CarActions.test.js.snap
@@ -3,7 +3,6 @@
 exports[`<CardActions renders the CardActions component properly 1`] = `
 .emotion-4 {
   box-sizing: border-box;
-  display: grid;
   grid-gap: 0.5rem;
   grid-template-columns: repeat(2,1fr);
 }

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -16,7 +16,6 @@ import {
 import Box from '../Box';
 
 const Grid = styled(Box)`
-  display: grid;
   ${alignContent};
   ${alignItems};
   ${gridAutoFlow};
@@ -41,6 +40,10 @@ Grid.propTypes = {
   ...gridRowGap.propTypes,
   ...justifyContent.propTypes,
   ...justifyItems.propTypes
+};
+
+Grid.defaultProps = {
+  display: 'grid'
 };
 
 export default Grid;

--- a/src/Header/__tests__/__snapshots__/Header.test.js.snap
+++ b/src/Header/__tests__/__snapshots__/Header.test.js.snap
@@ -75,6 +75,7 @@ exports[`<Header /> renders with heading and a button 1`] = `
 
 <header
   className="emotion-6 emotion-7"
+  display="grid"
 >
   <h1
     className="emotion-0 emotion-1"
@@ -121,6 +122,7 @@ exports[`<Header /> renders with heading and no buttons 1`] = `
 
 <header
   className="emotion-2 emotion-3"
+  display="grid"
 >
   <h1
     className="emotion-0 emotion-1"
@@ -264,6 +266,7 @@ exports[`<Header /> renders with heaeding and multiple buttons 1`] = `
 
 <header
   className="emotion-10 emotion-11"
+  display="grid"
 >
   <h1
     className="emotion-0 emotion-1"


### PR DESCRIPTION
Before this change you couldn't overwrite the display type of a pane or card. The pane and card should not be limited by the grid display style.