### PR TITLE
fix a regression in font weight for accordion header text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/AccordionSection/StyledAccordionHeadingText.js
+++ b/src/AccordionSection/StyledAccordionHeadingText.js
@@ -6,6 +6,7 @@ export const StyledText = styled(Flex)`
   background: none;
   border: none;
   font-size: inherit;
+  font-weight: normal;
   padding: 0;
 `;
 

--- a/src/AccordionSection/StyledAccordionHeadingText.js
+++ b/src/AccordionSection/StyledAccordionHeadingText.js
@@ -6,7 +6,7 @@ export const StyledText = styled(Flex)`
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: ${props => props.theme.fontWeights.regular};
   padding: 0;
 `;
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -75,7 +75,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 
@@ -187,7 +187,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 
@@ -300,7 +300,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 
@@ -412,7 +412,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -75,8 +75,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {
@@ -187,8 +187,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {
@@ -300,8 +300,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {
@@ -412,8 +412,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionHeader.test.js.snap
@@ -76,6 +76,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {
@@ -187,6 +188,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {
@@ -299,6 +301,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {
@@ -410,6 +413,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -75,8 +75,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {
@@ -211,8 +211,8 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  padding: 0;
   font-weight: normal;
+  padding: 0;
 }
 
 .emotion-0 {

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -75,7 +75,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 
@@ -211,7 +211,7 @@ section:last-child .emotion-7 {
   background: none;
   border: none;
   font-size: inherit;
-  font-weight: normal;
+  font-weight: 400;
   padding: 0;
 }
 

--- a/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
+++ b/src/AccordionSection/__tests__/__snapshots__/AccordionSection.test.js.snap
@@ -76,6 +76,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {
@@ -211,6 +212,7 @@ section:last-child .emotion-7 {
   border: none;
   font-size: inherit;
   padding: 0;
+  font-weight: normal;
 }
 
 .emotion-0 {


### PR DESCRIPTION
When the element type for Accordion header text was changed from button
to span, it gained a font-weight setting that made it too bold.