### PR TITLE
Expand brand colors and update auto complete to use them

### DIFF
--- a/src/AutoComplete/StyledAutoComplete.js
+++ b/src/AutoComplete/StyledAutoComplete.js
@@ -36,7 +36,6 @@ const getStyles = ({ radii, shadows, brandFont, space }) => ({
     marginBottom: space.smallest,
     marginTop: space.smallest
   }),
-  dropdownIndicator: addStyles({ display: 'none' }),
   control: addStyles({ boxShadow: 'none' }),
   indicatorSeparator: addStyles({ display: 'none' }),
   input: addStyles({ marginTop: `-${space.smallest}` }),

--- a/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -166,7 +166,10 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
 
 .emotion-11 {
   color: #E0E1E2;
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding: 8px;
   -webkit-transition: color 150ms;
   transition: color 150ms;
@@ -483,7 +486,10 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
 
 .emotion-11 {
   color: #E0E1E2;
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding: 8px;
   -webkit-transition: color 150ms;
   transition: color 150ms;
@@ -800,7 +806,10 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
 
 .emotion-11 {
   color: #E0E1E2;
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding: 8px;
   -webkit-transition: color 150ms;
   transition: color 150ms;
@@ -1117,7 +1126,10 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
 
 .emotion-11 {
   color: #E0E1E2;
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding: 8px;
   -webkit-transition: color 150ms;
   transition: color 150ms;

--- a/src/AutoComplete/buildReactSelectThemeOverrides.js
+++ b/src/AutoComplete/buildReactSelectThemeOverrides.js
@@ -1,9 +1,9 @@
-export default ({ colors: { intent, monochrome, palette }, radii }) => ({
+export default ({ colors: { intent, monochrome }, radii }) => ({
   borderRadius: radii.small,
   colors: {
-    primary: palette.blue.default,
-    primary75: palette.blue.darker,
-    primary50: palette.blue.dark,
+    primary: intent.brand.default,
+    primary75: intent.brand.darker,
+    primary50: intent.brand.dark,
     primary25: monochrome.grey10,
     danger: intent.danger.default,
     dangerLight: intent.danger.light,

--- a/src/Button/variants.js
+++ b/src/Button/variants.js
@@ -3,18 +3,18 @@ import { lighten, darken } from 'polished';
 const variants = ({ theme, variant }) => {
   const variantMap = {
     primary: {
-      backgroundColor: theme.colors.brand.dark,
-      color: theme.colors.brand.light,
+      backgroundColor: theme.colors.intent.brand.dark,
+      color: theme.colors.intent.brand.light,
       '&:hover:enabled': {
-        backgroundColor: darken(0.1, theme.colors.brand.dark)
+        backgroundColor: darken(0.1, theme.colors.intent.brand.dark)
       },
       '&:active:enabled': {
-        backgroundColor: lighten(0.1, theme.colors.brand.dark)
+        backgroundColor: lighten(0.1, theme.colors.intent.brand.dark)
       },
       '&:focus:enabled': {
         border: '1px solid transparent',
         boxShadow: `0 0 0 1px ${theme.colors.monochrome.white}, 0 0 0 2px ${
-          theme.colors.brand.dark
+          theme.colors.intent.brand.dark
         }`
       }
     },
@@ -30,17 +30,17 @@ const variants = ({ theme, variant }) => {
       '&:hover:enabled': {
         border: `1px solid ${theme.colors.border.dark}`,
         i: {
-          color: theme.colors.brand.dark
+          color: theme.colors.intent.brand.dark
         }
       },
       '&:active:enabled': {
-        color: theme.colors.brand.dark,
+        color: theme.colors.intent.brand.dark,
         backgroundColor: theme.colors.background.default
       },
       '&:focus:enabled': {
         border: '1px solid transparent',
         boxShadow: `0 0 0 1px ${theme.colors.monochrome.white}, 0 0 0 2px ${
-          theme.colors.brand.dark
+          theme.colors.intent.brand.dark
         }`
       }
     },
@@ -63,7 +63,7 @@ const variants = ({ theme, variant }) => {
       },
       '&:focus:enabled': {
         boxShadow: `0 0 0 1px ${theme.colors.monochrome.white}, 0 0 0 2px ${
-          theme.colors.brand.dark
+          theme.colors.intent.brand.dark
         }`
       },
       '&:disabled': {

--- a/src/DatePicker/StyledDatePicker.js
+++ b/src/DatePicker/StyledDatePicker.js
@@ -45,15 +45,15 @@ const StyledDatePicker = styled(DayPicker)`
   }
 
   .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-    background-color: ${props => props.theme.colors.brand.dark};
-    color: ${props => props.theme.colors.brand.light};
+    background-color: ${props => props.theme.colors.intent.brand.dark};
+    color: ${props => props.theme.colors.intent.brand.light};
     font-weight: ${props => props.theme.fontWeights.regular};
   }
 
   &:not(.DayPicker--interactionDisabled)
     .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
-    background-color: ${props => props.theme.colors.brand.light};
-    color: ${props => props.theme.colors.brand.dark};
+    background-color: ${props => props.theme.colors.intent.brand.light};
+    color: ${props => props.theme.colors.intent.brand.dark};
   }
 
   .DayPicker-NavBar {

--- a/src/Input/StyledInput.js
+++ b/src/Input/StyledInput.js
@@ -23,8 +23,8 @@ const baseStyles = ({ theme }) => css`
   ${placeholder({ color: theme.colors.grey60 })};
 
   &:focus {
-    border: ${theme.borderWidth.small} solid ${theme.colors.brand.dark};
-    box-shadow: 0 0 8px ${transparentize(0.9, theme.colors.brand.light)};
+    border: ${theme.borderWidth.small} solid ${theme.colors.intent.brand.dark};
+    box-shadow: 0 0 8px ${transparentize(0.9, theme.colors.intent.brand.light)};
     outline: none;
   }
 

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -52,7 +52,10 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
           },
           "brand": Object {
             "dark": "#081D17",
+            "darker": "#081D17",
+            "default": "#081D17",
             "light": "#C0F9DA",
+            "lighter": "#C0F9DA",
           },
           "bronze": "#CC7700",
           "bronzeDark": "#AA5500",
@@ -76,6 +79,13 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
             "disabled": "rgba(190,190,192,0.7)",
           },
           "intent": Object {
+            "brand": Object {
+              "dark": "#081D17",
+              "darker": "#081D17",
+              "default": "#081D17",
+              "light": "#C0F9DA",
+              "lighter": "#C0F9DA",
+            },
             "danger": Object {
               "dark": "#6c1c1c",
               "darker": "#2b0b0b",
@@ -408,7 +418,10 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
                 },
                 "brand": Object {
                   "dark": "#081D17",
+                  "darker": "#081D17",
+                  "default": "#081D17",
                   "light": "#C0F9DA",
+                  "lighter": "#C0F9DA",
                 },
                 "bronze": "#CC7700",
                 "bronzeDark": "#AA5500",
@@ -432,6 +445,13 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
                   "disabled": "rgba(190,190,192,0.7)",
                 },
                 "intent": Object {
+                  "brand": Object {
+                    "dark": "#081D17",
+                    "darker": "#081D17",
+                    "default": "#081D17",
+                    "light": "#C0F9DA",
+                    "lighter": "#C0F9DA",
+                  },
                   "danger": Object {
                     "dark": "#6c1c1c",
                     "darker": "#2b0b0b",

--- a/src/theme/colors/brand.js
+++ b/src/theme/colors/brand.js
@@ -1,7 +1,7 @@
-export const light = '#C0F9DA';
-export const dark = '#081D17';
-
 export default {
-  dark,
-  light
+  lighter: '#C0F9DA',
+  light: '#C0F9DA',
+  default: '#081D17',
+  dark: '#081D17',
+  darker: '#081D17'
 };

--- a/src/theme/colors/intent.js
+++ b/src/theme/colors/intent.js
@@ -1,4 +1,5 @@
 import { blue, green, red, orange } from './palette';
+import brand from './brand';
 
 export const danger = red;
 export const info = blue;
@@ -6,6 +7,7 @@ export const success = green;
 export const warning = orange;
 
 export default {
+  brand,
   danger,
   info,
   success,

--- a/stories/colors.stories.js
+++ b/stories/colors.stories.js
@@ -140,14 +140,6 @@ storiesOf('Colors', module).add('Border', () => (
   />
 ));
 
-storiesOf('Colors', module).add('Brand', () => (
-  <Swatches
-    colorGroup="brand"
-    modifierOverride="monochrome"
-    palette={colors.brand}
-  />
-));
-
 storiesOf('Colors', module).add('Icon', () => (
   <Swatches
     colorGroup="icon"


### PR DESCRIPTION
[#166940987]

* Include brand colors in intent
* Add remaining color scale to brand colors
* Update auto-complete to use brand color instead of blue
* Show dropdown indicator for auto complete 
<img width="1047" alt="Screen Shot 2019-06-27 at 11 21 09 AM" src="https://user-images.githubusercontent.com/126970/60278596-bbeb7a00-98cd-11e9-9538-486f322a1c89.png">
