### PR TITLE
Explicitly pass size prop to Avatar subcomponents

### DIFF
--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { sizes } from '../theme/avatars';
 import { colorForString } from '../utils';
 import StyledAvatar from './StyledAvatar';
 import StyledAvatarText from './StyledAvatarText';
@@ -25,7 +26,7 @@ const getInitials = name => {
   return firstInitial;
 };
 
-const Avatar = ({ name, subtle, ...props }) => {
+const Avatar = ({ name, subtle, size, ...props }) => {
   const baseColor = colorForString(name, AVATAR_COLORS);
 
   return (
@@ -36,11 +37,12 @@ const Avatar = ({ name, subtle, ...props }) => {
         border: '1px solid',
         borderRadius: '50%',
         justifyContent: 'center',
+        size,
         subtle,
         ...props
       }}
     >
-      <StyledAvatarText {...{ ...props, baseColor, subtle }}>
+      <StyledAvatarText {...{ baseColor, size, subtle }}>
         {getInitials(name).toUpperCase()}
       </StyledAvatarText>
     </StyledAvatar>
@@ -58,12 +60,18 @@ Avatar.propTypes = {
   name: PropTypes.string.isRequired,
 
   /**
+   * Visual size of the Avatar component
+   */
+  size: PropTypes.oneOf(Object.keys(sizes)),
+
+  /**
    * Use a subtle version of the avatar's color styling.
    * */
   subtle: PropTypes.bool
 };
 
 Avatar.defaultProps = {
+  size: 'default',
   subtle: false
 };
 

--- a/src/Avatar/StyledAvatar.js
+++ b/src/Avatar/StyledAvatar.js
@@ -30,11 +30,7 @@ export const StyledAvatar = ({
 
 StyledAvatar.propTypes = {
   baseColor: PropTypes.string.isRequired,
-  size: PropTypes.oneOf(Object.keys(sizes))
-};
-
-StyledAvatar.defaultProps = {
-  size: 'default'
+  size: PropTypes.oneOf(Object.keys(sizes)).isRequired
 };
 
 export default withTheme(StyledAvatar);

--- a/src/Avatar/StyledAvatarText.js
+++ b/src/Avatar/StyledAvatarText.js
@@ -19,11 +19,7 @@ export const StyledAvatarText = ({
 };
 
 StyledAvatarText.propTypes = {
-  size: PropTypes.oneOf(Object.keys(sizes))
-};
-
-StyledAvatarText.defaultProps = {
-  size: 'default'
+  size: PropTypes.oneOf(Object.keys(sizes)).isRequired
 };
 
 export default withTheme(StyledAvatarText);


### PR DESCRIPTION
Before, we would indirectly pass size to the `StyledAvatar` and
`StyleAvatarText` by passing along all props we received down to them.
This lead to odd behavior when trying to style the `StyledAvatar` using
styled-system.

Take the following example:

```js
<Avatar mr="regular" name="Ralph Bot" />
```

The margin-right regular would then be applied to the `StyledAvatar`
component as well as the `StyledAvatarText` component which would lead
to unusual results. We only want the styled-system props to apply to the
`StyledAvatar` component.