### PR TITLE
Fix Avatar borders issues

### DIFF
--- a/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
@@ -3,9 +3,9 @@
 exports[`<Avatar /> renders properly 1`] = `
 .emotion-2 {
   box-sizing: border-box;
+  border: 1px solid;
   border-color: #29863A;
   border-radius: 50%;
-  border: 1px solid;
   background-color: #29863A;
   height: 24px;
   width: 24px;

--- a/src/Box/Box.js
+++ b/src/Box/Box.js
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import {
+  borders,
   borderColor,
   borderRadius,
-  borders,
   boxShadow,
   color,
   display,
@@ -21,9 +21,9 @@ import {
 
 const Box = styled.div`
   box-sizing: border-box;
+  ${borders};
   ${borderColor};
   ${borderRadius};
-  ${borders};
   ${boxShadow};
   ${color};
   ${display};
@@ -41,9 +41,9 @@ const Box = styled.div`
 `;
 
 Box.propTypes = {
+  ...borders.propTypes,
   ...borderColor.propTypes,
   ...borderRadius.propTypes,
-  ...borders.propTypes,
   ...boxShadow.propTypes,
   ...color.propTypes,
   ...display.propTypes,


### PR DESCRIPTION
Order of styled-system style props on the Box component prevented
borderColors from working. Order is IMPORTANT when leveraging
styledSystem style props. Be careful alphabetizing, especially if you
auto alphabetize declarations with a macro... like I did :(

In CSS you can override a generic style by adding a another style below
it in the same declaration. For example:

```
.myBox {
  border: 1px solid #00000;
  border-color: #00FF00;
}
```

will result in a 1px solid border with a color of #00FF00 (nothing new
here).

-------

The problem occurred due to the following declaration in Box

```
const Box = styled.div`
  box-sizing: border-box;
  ${borderColor};
  ${borderRadius};
  ${borders};
  ...
`
```

Note that border color is above borders. If you were to leverage both
the borderColor and border style props on a component they will be
slotted into the output CSS in that order. For Example:

<Box border="1px solid" borderColor="#00ff00" />

will result in:

Box {
  border-color: #00FF00;
  border: 1px solid;
}

"border" is a shorthand declaration, expanding to border width, style,
and color. It defaults color to black and overrides the original
declaration of #00FF00 since it comes AFTER border-color in the style
declaration.