### PR TITLE
Autocomplete adjustments

### DIFF
--- a/src/AutoComplete/StyledMultiValue.js
+++ b/src/AutoComplete/StyledMultiValue.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { colorForString } from '../utils';
+import { palette } from '../theme/colors';
+
 import Badge from '../Badge';
 import Icon from '../Icon';
 
 const StyledMultiValue = ({ data, data: { label }, removeProps }) => {
+  const paletteColor = colorForString(label, Object.keys(palette));
+
   const iconEnd = (
     <Icon
       aria-label="remove"
@@ -21,6 +26,7 @@ const StyledMultiValue = ({ data, data: { label }, removeProps }) => {
         iconEnd,
         mb: 'smallest',
         mr: 'smallest',
+        paletteColor,
         subtle: true,
         variant: 'pill',
         ...data

--- a/src/AutoComplete/StyledMultiValue.js
+++ b/src/AutoComplete/StyledMultiValue.js
@@ -22,6 +22,7 @@ const StyledMultiValue = ({ data, data: { label }, removeProps }) => {
         mb: 'smallest',
         mr: 'smallest',
         subtle: true,
+        variant: 'pill',
         ...data
       }}
     >

--- a/src/AutoComplete/__tests__/StyledMutliValue.test.js
+++ b/src/AutoComplete/__tests__/StyledMutliValue.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import colorForString from '../../utils/colorForString';
+
+import StyledMultiValue from '../StyledMultiValue';
+
+jest.mock('../../utils/colorForString.js');
+
+const noop = () => null;
+
+describe('<StyledMultiValue />', () => {
+  it('uses colorForString to determine badge color', () => {
+    colorForString.mockReturnValue('green');
+    const props = {
+      data: {
+        label: 'Apples'
+      },
+      removeProps: {
+        onClick: noop,
+        onMouseDown: noop,
+        onTouchEnd: noop
+      }
+    };
+
+    const wrapper = shallow(<StyledMultiValue {...props} />);
+
+    expect(wrapper.find('Badge')).toHaveProp({ paletteColor: 'green' });
+  });
+});

--- a/stories/autoComplete.stories.js
+++ b/stories/autoComplete.stories.js
@@ -122,8 +122,11 @@ stories.add('default', () => (
 
     <AutoCompleteExample
       id="auto-complete-2"
-      label="AutoComplete with unstyled pill badges"
-      options={neutralOptions.map(option => ({ ...option, variant: 'pill' }))}
+      label="AutoComplete with unstyled default badges"
+      options={neutralOptions.map(option => ({
+        ...option,
+        variant: 'default'
+      }))}
       variant={select('Variant', variantOptions, 'default')}
     />
 
@@ -143,11 +146,11 @@ stories.add('default', () => (
 
     <AutoCompleteExample
       id="auto-complete-5"
-      label="AutoComplete with subtle color pill badges"
+      label="AutoComplete with subtle color default badges"
       options={colorOptions.map(option => ({
         ...option,
         subtle: true,
-        variant: 'pill'
+        variant: 'default'
       }))}
       variant={select('Variant', variantOptions, 'default')}
     />


### PR DESCRIPTION
* Make pill the default badge used in AutoComplete 
* Display badges in autocomplete with colors, generated by `colorForString` with the given label

![image](https://user-images.githubusercontent.com/105694/61537678-b7fed380-aa05-11e9-8153-61ff4f55698b.png)
