### PR TITLE
Fix shouldCloseOnOverlayClick Modal bug

### DIFF
--- a/src/Modal/__tests__/__snapshots__/buildModalCss.test.js.snap
+++ b/src/Modal/__tests__/__snapshots__/buildModalCss.test.js.snap
@@ -38,7 +38,6 @@ exports[`buildModalCss modalCss is provided renders properly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
-  width: calc(100% - 4rem);
   background: red;
 }
 
@@ -85,7 +84,6 @@ exports[`buildModalCss no additional css provided renders properly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
-  width: calc(100% - 4rem);
 }
 
 <div
@@ -132,7 +130,6 @@ exports[`buildModalCss overlayCss is provided renders properly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
-  width: calc(100% - 4rem);
 }
 
 <div

--- a/src/Modal/buildModalCss.js
+++ b/src/Modal/buildModalCss.js
@@ -8,7 +8,6 @@ const baseModalCss = theme => css`
   height: calc(100% - ${theme.space.largest});
   justify-content: center;
   outline: none;
-  width: calc(100% - ${theme.space.largest});
 `;
 
 const baseOverlayCss = theme => css`

--- a/stories/modal.stories.js
+++ b/stories/modal.stories.js
@@ -41,14 +41,17 @@ class ModalStory extends React.Component {
         <Button varient="primary" onClick={this.openModal}>
           Launch Modal
         </Button>
-        <Modal isOpen={modalIsOpen} onRequestClose={this.closeModal}>
+        <Modal
+          isOpen={modalIsOpen}
+          onRequestClose={this.closeModal}
+          modalCss={{ width }}
+        >
           <Card
             as="section"
             boxShadow="elevation2"
             gridTemplateRows="auto 1fr auto"
             maxHeight={maxHeight}
             overflow="hidden"
-            width={width}
           >
             <Grid
               alignItems="center"


### PR DESCRIPTION
The calculated width on the modal was preventing the ability to close
the modal by clicking the area outside of the modal content. This was
because the modal itself was being drawn much wider than the actual
content. So it looked like you could click the overlay even though you
couldn't.

[#167382149]