### PR TITLE
Upgrade Styled-System

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-popover": "^0.5.10",
     "react-select": "^3.0.4",
     "react-tippy": "^1.2.3",
-    "styled-system": "^3.1.11"
+    "styled-system": "^5.0.15"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/Avatar/StyledAvatar.js
+++ b/src/Avatar/StyledAvatar.js
@@ -9,6 +9,7 @@ export const StyledAvatar = ({
   size,
   subtle,
   theme: { avatarSizes },
+  border,
   baseColor,
   ...props
 }) => {
@@ -21,6 +22,7 @@ export const StyledAvatar = ({
         width: avatarSizes[size],
         height: avatarSizes[size],
         bg,
+        border,
         borderColor,
         ...props
       }}

--- a/src/Box/Box.js
+++ b/src/Box/Box.js
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 import {
   borders,
-  borderColor,
-  borderRadius,
   boxShadow,
   color,
   display,
@@ -22,8 +20,6 @@ import {
 const Box = styled.div`
   box-sizing: border-box;
   ${borders};
-  ${borderColor};
-  ${borderRadius};
   ${boxShadow};
   ${color};
   ${display};
@@ -42,8 +38,6 @@ const Box = styled.div`
 
 Box.propTypes = {
   ...borders.propTypes,
-  ...borderColor.propTypes,
-  ...borderRadius.propTypes,
   ...boxShadow.propTypes,
   ...color.propTypes,
   ...display.propTypes,

--- a/src/CardPreview/CardPreview.js
+++ b/src/CardPreview/CardPreview.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import { ratio } from 'styled-system';
+import { ratio } from '../utils';
 
 import Box from '../Box';
 

--- a/src/CardRow/__tests__/__snapshots__/CardRow.test.js.snap
+++ b/src/CardRow/__tests__/__snapshots__/CardRow.test.js.snap
@@ -3,12 +3,12 @@
 exports[`<CardRow /> renders a CardRow properly 1`] = `
 .emotion-0 {
   box-sizing: border-box;
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/src/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -143,8 +143,8 @@ exports[`<DatePicker /> properly renders a DatePicker 1`] = `
 
 .emotion-6 {
   box-sizing: border-box;
-  margin-left: 0.75rem;
   margin-right: 0.75rem;
+  margin-left: 0.75rem;
 }
 
 .emotion-4 {

--- a/src/utils/__tests__/ratio.test.js
+++ b/src/utils/__tests__/ratio.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { create } from 'react-test-renderer';
+import styled from '@emotion/styled';
+
+import ratio from '../ratio';
+
+describe('ratio', () => {
+  it('provides support for passing in ratio css as prop', () => {
+    const ExampleComponent = styled.div`
+      ${ratio};
+    `;
+
+    const rendered = create(
+      <ExampleComponent ratio={9 / 16}>Hello World</ExampleComponent>
+    );
+
+    expect(rendered.toJSON()).toHaveStyleRule('height', '0');
+    expect(rendered.toJSON()).toHaveStyleRule('padding-bottom', '56.25%');
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,5 @@
-export { default as colorForString } from './colorForString'; // eslint-disable-line import/prefer-default-export
+export * from './columns';
+export { default as colorForString } from './colorForString';
+export { default as ratio } from './ratio';
+export { default as textOverflow } from './textOverflow';
+export { default as whiteSpace } from './whiteSpace';

--- a/src/utils/ratio.js
+++ b/src/utils/ratio.js
@@ -1,0 +1,14 @@
+import { style } from 'styled-system';
+
+const ratioPadding = style({
+  prop: 'ratio',
+  cssProperty: 'paddingBottom',
+  transformValue: n => `${n * 100}%`
+});
+
+const ratio = props => ({
+  height: 0,
+  ...ratioPadding(props)
+});
+
+export default ratio;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,6 +1936,90 @@
     telejson "^2.1.1"
     util-deprecate "^1.0.2"
 
+"@styled-system/background@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/background/-/background-5.0.15.tgz#7b06fdb0191ad3d0817d3e7c9a00db1a4481ef25"
+  integrity sha512-lJHTuihs97iucZvm2264mDJamU/jR37qO3Vbhrc9I7kEC9SVjMyYFlMw5xjTFY0hm0BNlFRYjF4vdKMy+qQQPg==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/border@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/border/-/border-5.0.15.tgz#881cabcd1a71b5dca5af643cc604a2d747ca58ce"
+  integrity sha512-YuUKFuX+CcQvXlnUejUqIEwrqxlzplZvuShJYMIuWGPAoiitT1P5MY5v4Rsq3ADBjB4WVh7BGZFDTRowOnSQRQ==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/color@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/color/-/color-5.0.15.tgz#a1311376b353209983a90bc679023f4c421f0de4"
+  integrity sha512-fubfpc22it9xJKXk/3MjuNos1YJyaqrpxbOOXUPE1s/xPtZJuty2ML9aRHEPWKTgGcblpGqA6PZr6c7gB+XITw==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/core@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/core/-/core-5.0.15.tgz#7ef417637ad49b7eaf09c6685cf3a8f42e9081af"
+  integrity sha512-Tztt8+g9WROfLsWOzY4YifOvVY07GkZDcV14FE6+wF7d1dPupUBD13fdqNz8QLBzKpE8fGi1umAWh0Ug2+1K9g==
+  dependencies:
+    object-assign "^4.1.1"
+
+"@styled-system/flexbox@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/flexbox/-/flexbox-5.0.15.tgz#fb44ec4873a5af1128ed5210204566c1ddd899e7"
+  integrity sha512-Dv131+4XwpT+yccvAbv4JOZ+FmleIzzCtfvB/5i2/T4pyVEp2nIFDF10bXE/Hy+ZsI8v6UPldaGXfBVPnz/7uA==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/grid@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/grid/-/grid-5.0.15.tgz#5eb8e50d69b5edb23850efb8715da766c972448b"
+  integrity sha512-EzQL7UI2dPhh1iV2SWPDXAFNppK4Y3IuYcmn9GUdAgZkwZrrQbJWWvjVzfH2UVBhzfygQ+zAobwXdozQRatSyQ==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/layout@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/layout/-/layout-5.0.15.tgz#978520cdf3c2c3efc5bee763f299d5a8bc6bf1d0"
+  integrity sha512-GbilYkniBArQe2854Fa35V/ExQYBWEAw/6iQC2Tw5iGAozMxXVi5A+vhaHoWtov/U1K7GEkputiQp/X+pIX2mg==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/position@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/position/-/position-5.0.15.tgz#3eed962d586979fd1ec2982a6cf8682faab87ae3"
+  integrity sha512-irsnc74+cTDU3eVkhSxj+mWEunL7t79Cxw8ChJqxUEwePmBdwYBC24aY1kdOpOj7d6zXMAVV6YjLG5fMDwidfA==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/shadow@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/shadow/-/shadow-5.0.15.tgz#de6c5d879c9dfa6bec280537faf7ce5858d669ea"
+  integrity sha512-5t/CyHNBFa29/oAyy9EWi7ZS85ADtl0+PTYcg0zOOaPFeG8LJk3C9UclqGg/ms0Lr6UFzzVjEKI8KTXGyMQaPw==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/space@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/space/-/space-5.0.15.tgz#46a05b5cf7310db4d443219d7fa655569d45cdf3"
+  integrity sha512-1zCn2YgLEYgJd5uvdzSNBSq/GbOi0spxSnZQ+lhz9yIfFzgsjh+H9CQY78RMjl6S4bzhiFa9B07nMZb+x0qDdw==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/typography@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/typography/-/typography-5.0.15.tgz#8e253a94af46b749ef7635e1f92b6580756b4507"
+  integrity sha512-slm9s38IjV8eu8MmumyvcQ14FqhbJ0i5wYcN7jTZfzmDdPHU6hNkvlMe4zeZTfHa8XI+pmHBLiMFxC/zMc8w9g==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
+"@styled-system/variant@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@styled-system/variant/-/variant-5.0.15.tgz#c2123305fb9473f292573ee9b4ad312ce72e5530"
+  integrity sha512-epLSEwchKX3N3vv2wjHN60HbysCGiiv3oFqn6/q0stZ57kZ3mzsofxlmbCWW33XCSLykqMZ1Gg8+jEBfR1HKqA==
+  dependencies:
+    "@styled-system/core" "^5.0.15"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.0.0.tgz#5acf239cd2747b1a36ec7e708de05d914cb9b948"
@@ -11515,13 +11599,24 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-styled-system@^3.1.11:
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-3.1.11.tgz#a91a38cf7a0f0e625b897a04fdd506a359a3629f"
-  integrity sha512-d0p32F7Y55uRWNDb1P0JcIiGVi13ZxiSCvn8zNS68exAKW9Q5jp+IGTXUIavQOD/J8r3tydtE3vRk8Ii2i39HA==
+styled-system@^5.0.15:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.0.15.tgz#ebb9567d4ee22dd50fd6a4fa313b958f0ad5bd43"
+  integrity sha512-wnKiY5Ds2ATffLN6qhHFlPlDEOxISWwo9H/55+vU2dIxNeUhtfNgPB2Nbek9MB+kiKHQhxcwUgfjk1ZWDH6nVA==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.6.2"
+    "@styled-system/background" "^5.0.15"
+    "@styled-system/border" "^5.0.15"
+    "@styled-system/color" "^5.0.15"
+    "@styled-system/core" "^5.0.15"
+    "@styled-system/flexbox" "^5.0.15"
+    "@styled-system/grid" "^5.0.15"
+    "@styled-system/layout" "^5.0.15"
+    "@styled-system/position" "^5.0.15"
+    "@styled-system/shadow" "^5.0.15"
+    "@styled-system/space" "^5.0.15"
+    "@styled-system/typography" "^5.0.15"
+    "@styled-system/variant" "^5.0.15"
+    object-assign "^4.1.1"
 
 stylelint-config-recommended@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
[#167405709]

* Upgrade style system to  from 3.1.11 to 5.0.15. We were previously
blocked on this due to the missing ratio util. I've recreated the ratio
util within arbor to let us upgrade.
* Update existing components to use some of the newer features and fixes
from the latest styled-system (Datepicker, Avatar, Box, CardPreview)