### PR TITLE
Rework Menu Component with MenuItem Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "emotion-theming": "^10.0.0",
     "lodash": "^4.17.11",
     "polished": "^2.2.0",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "react": "^16.5.2",
     "react-day-picker": "^7.3.0",
     "react-dom": "^16.5.2",

--- a/src/Menu/ControlledMenuItem.js
+++ b/src/Menu/ControlledMenuItem.js
@@ -5,15 +5,15 @@ import PropTypes from 'prop-types';
 import { hideVisually } from 'polished';
 
 import { ENTER_KEY, SPACEBAR } from '../constants';
-import StyledMenuItem from './StyledMenuItem';
-import Text from '../Text';
-import Icon from '../Icon';
 import Flex from '../Flex';
+import Icon from '../Icon';
+import MenuItem from '../MenuItem';
+import Text from '../Text';
 
 const MIN_WIDTH = '120px';
 const PADDING = '8px';
 
-class MenuItem extends React.PureComponent {
+class ControlledMenuItem extends React.PureComponent {
   componentDidMount() {
     document.addEventListener('keydown', this.onKeyDown, true);
   }
@@ -24,9 +24,9 @@ class MenuItem extends React.PureComponent {
 
   onKeyDown = e => {
     const { key } = e;
-    const { focused } = this.props;
+    const { isFocused } = this.props;
 
-    if (!focused) {
+    if (!isFocused) {
       return;
     }
 
@@ -43,29 +43,29 @@ class MenuItem extends React.PureComponent {
 
   render() {
     const {
-      selected,
+      MenuItemComponent,
       baseColor,
       iconName,
       id,
+      isFocused,
+      isSelected,
       label,
-      secondaryLabel,
       name,
-      value,
-      focused
+      secondaryLabel,
+      value
     } = this.props;
 
     return (
-      <StyledMenuItem
+      <MenuItemComponent
         {...{
-          baseColor,
-          selected,
-          focused,
-          role: 'option',
-          'aria-selected': selected,
+          'aria-selected': isSelected,
           alignItems: 'center',
-          height: '40px',
+          isFocused,
+          isSelected,
           onClick: this.onSelect,
-          onKeyPress: this.onKeyDown
+          onKeyPress: this.onKeyDown,
+          role: 'option',
+          ...this.props
         }}
       >
         <input {...{ id, name, value, css: hideVisually(), type: 'hidden' }} />
@@ -111,43 +111,12 @@ class MenuItem extends React.PureComponent {
             </Flex>
           )}
         </Flex>
-      </StyledMenuItem>
+      </MenuItemComponent>
     );
   }
 }
 
-MenuItem.propTypes = {
-  /**
-   * Indicates whether or not the menu item is selected
-   */
-  selected: PropTypes.bool,
-
-  /**
-   * Callback to run when a selection is made. This is generally intended for
-   * internal use with the Menu component.
-   */
-  onSelect: PropTypes.func,
-
-  /**
-   * Main label text for the menu item
-   */
-  label: PropTypes.string.isRequired,
-
-  /**
-   * Secondary label text for the menu item
-   */
-  secondaryLabel: PropTypes.string,
-
-  /**
-   * HTML input name property for the input field
-   */
-  name: PropTypes.string.isRequired,
-
-  /**
-   * HTML input value property for the input field
-   */
-  value: PropTypes.string.isRequired,
-
+ControlledMenuItem.propTypes = {
   /**
    * Base color to use for the menu item
    */
@@ -166,16 +135,53 @@ MenuItem.propTypes = {
   /**
    * Whether or not the current menu item is focused
    */
-  focused: PropTypes.bool
+  isFocused: PropTypes.bool,
+
+  /**
+   * Indicates whether or not the menu item is selected
+   */
+  isSelected: PropTypes.bool,
+
+  /**
+   * Main label text for the menu item
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * Component used to render each menu item
+   */
+  MenuItemComponent: PropTypes.elementType,
+
+  /**
+   * HTML input name property for the input field
+   */
+  name: PropTypes.string.isRequired,
+
+  /**
+   * Callback to run when a selection is made. This is generally intended for
+   * internal use with the Menu component.
+   */
+  onSelect: PropTypes.func,
+
+  /**
+   * Secondary label text for the menu item
+   */
+  secondaryLabel: PropTypes.string,
+
+  /**
+   * HTML input value property for the input field
+   */
+  value: PropTypes.string.isRequired
 };
 
-MenuItem.defaultProps = {
+ControlledMenuItem.defaultProps = {
+  MenuItemComponent: MenuItem,
   baseColor: 'text.default',
   iconName: null,
-  secondaryLabel: null,
-  selected: false,
+  isFocused: false,
+  isSelected: false,
   onSelect: () => null,
-  focused: false
+  secondaryLabel: null
 };
 
-export default MenuItem;
+export default ControlledMenuItem;

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import snakeCase from 'lodash/snakeCase';
 
 import { ARROW_DOWN, ARROW_UP, HOME_KEY, END_KEY } from '../constants';
+import ControlledMenuItem from './ControlledMenuItem';
+import MenuItem from '../MenuItem';
 import StyledMenu from './StyledMenu';
-import MenuItem from './MenuItem';
 
 const NAVIGATION_KEYS = [ARROW_UP, ARROW_DOWN];
 
@@ -100,21 +101,22 @@ class Menu extends React.Component {
 
   renderMenuItem(menuItem, index) {
     const { currentlyFocused, selected } = this.state;
-    const { name } = this.props;
+    const { name, MenuItemComponent } = this.props;
     const isSelected = menuItem.value === selected;
     const id = this.domIdForMenuItem(menuItem);
-    const focused = index === currentlyFocused;
+    const isFocused = index === currentlyFocused;
 
     return (
-      <MenuItem
+      <ControlledMenuItem
         {...{
-          ...menuItem,
           id,
-          focused,
+          isFocused,
+          isSelected,
+          key: id,
+          MenuItemComponent,
           name,
-          selected: isSelected,
-          key: menuItem.label,
-          onSelect: this.onMenuItemSelect
+          onSelect: this.onMenuItemSelect,
+          ...menuItem
         }}
       />
     );
@@ -137,11 +139,6 @@ class Menu extends React.Component {
 
 Menu.propTypes = {
   /**
-   * Callback to run when a menu item is selected
-   */
-  onChange: PropTypes.func,
-
-  /**
    * Array of menu item objects to render as MenuItems in the Menu
    */
   menuItems: PropTypes.arrayOf(
@@ -154,9 +151,19 @@ Menu.propTypes = {
   ).isRequired,
 
   /**
+   * Component used to render each menu item
+   */
+  MenuItemComponent: PropTypes.elementType,
+
+  /**
    * Name of the menu for grouping the menu item DOM IDs
    */
   name: PropTypes.string.isRequired,
+
+  /**
+   * Callback to run when a menu item is selected
+   */
+  onChange: PropTypes.func,
 
   /**
    * Initial selected menu item value
@@ -165,6 +172,7 @@ Menu.propTypes = {
 };
 
 Menu.defaultProps = {
+  MenuItemComponent: MenuItem,
   onChange: () => null,
   selected: undefined
 };

--- a/src/Menu/__tests__/ControlledMenuItem.test.js
+++ b/src/Menu/__tests__/ControlledMenuItem.test.js
@@ -3,9 +3,9 @@ import React from 'react';
 import mountWithTheme from '../../../utils/mountWithTheme';
 import createWithTheme from '../../../utils/createWithTheme';
 import { ENTER_KEY, SPACEBAR } from '../../constants';
-import MenuItem from '../MenuItem';
+import ControlledMenuItem from '../ControlledMenuItem';
 
-describe('<MenuItem />', () => {
+describe('<ControlledMenuItem />', () => {
   const noop = () => null;
   const baseProps = {
     label: 'Ready to Clear',
@@ -18,12 +18,12 @@ describe('<MenuItem />', () => {
 
   function createWithProps(additionalProps) {
     const props = Object.assign({}, baseProps, additionalProps);
-    return createWithTheme(<MenuItem {...{ ...props }} />);
+    return createWithTheme(<ControlledMenuItem {...{ ...props }} />);
   }
 
   function mountWithProps(additionalProps) {
     const props = Object.assign({}, baseProps, additionalProps);
-    return mountWithTheme(<MenuItem {...{ ...props }} />);
+    return mountWithTheme(<ControlledMenuItem {...{ ...props }} />);
   }
 
   it('renders a MenuItem properly', () => {
@@ -57,7 +57,7 @@ describe('<MenuItem />', () => {
       context('menu item is focused', () => {
         it('calls the onSelect callback', () => {
           const onSelect = jest.fn();
-          const menu = mountWithProps({ onSelect, value, focused: true });
+          const menu = mountWithProps({ onSelect, value, isFocused: true });
 
           menu.instance().onKeyDown({ key, preventDefault: noop });
 
@@ -65,7 +65,7 @@ describe('<MenuItem />', () => {
         });
 
         it('prevents the default keydown event', () => {
-          const menu = mountWithProps({ focused: true });
+          const menu = mountWithProps({ isFocused: true });
           const preventDefault = jest.fn();
 
           menu.instance().onKeyDown({ key, preventDefault });
@@ -77,7 +77,7 @@ describe('<MenuItem />', () => {
       context('menu item is not focused', () => {
         it('does not call the onSelect callback', () => {
           const onSelect = jest.fn();
-          const menu = mountWithProps({ onSelect, value, focused: false });
+          const menu = mountWithProps({ onSelect, value, isFocused: false });
 
           menu.instance().onKeyDown({ key });
 
@@ -98,7 +98,7 @@ describe('<MenuItem />', () => {
       context('menu item is focused', () => {
         it('does not call the onSelect callback', () => {
           const onSelect = jest.fn();
-          const menu = mountWithProps({ onSelect, value, focused: true });
+          const menu = mountWithProps({ onSelect, value, isFocused: true });
 
           menu.instance().onKeyDown({ key: 'ArrowDown' });
 

--- a/src/Menu/__tests__/Menu.test.js
+++ b/src/Menu/__tests__/Menu.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 
 import { ARROW_DOWN, ARROW_UP, HOME_KEY, END_KEY } from '../../constants';
 import Menu from '../Menu';
+import MenuItem from '../ControlledMenuItem';
 
 describe('<Menu />', () => {
   const baseProps = {
@@ -23,7 +24,7 @@ describe('<Menu />', () => {
   }
 
   describe('children', () => {
-    it('renders each menuItem as a MenuItem', () => {
+    it('renders each menuItem as a ControlledMenuItem', () => {
       const menuItems = [
         {
           baseColor: 'grey',
@@ -39,7 +40,7 @@ describe('<Menu />', () => {
       const menu = shallowWithProps({ menuItems });
 
       expect(
-        menu.find('MenuItem').map(menuItem => menuItem.props().label)
+        menu.find(MenuItem).map(menuItem => menuItem.props().label)
       ).toEqual(['Ready to Clear', 'License Acquired']);
     });
 
@@ -55,7 +56,7 @@ describe('<Menu />', () => {
 
       expect(
         menu
-          .find('MenuItem')
+          .find(MenuItem)
           .first()
           .props().id
       ).toEqual('menu-item_clearance_state_ready_to_clear');
@@ -71,7 +72,7 @@ describe('<Menu />', () => {
       ];
       const menu = shallowWithProps({ menuItems, selected: 'ready_to_clear' });
 
-      expect(menu.find('MenuItem').props().selected).toBe(true);
+      expect(menu.find(MenuItem).props().isSelected).toBe(true);
     });
 
     it('properly sets other MenuItems as not selected', () => {
@@ -84,7 +85,7 @@ describe('<Menu />', () => {
       ];
       const menu = shallowWithProps({ menuItems, selected: 'ready_to_clear' });
 
-      expect(menu.find('MenuItem').props().selected).toBe(false);
+      expect(menu.find(MenuItem).props().isSelected).toBe(false);
     });
 
     it('sets aria-activedescendant to focused menu item id', () => {
@@ -119,7 +120,7 @@ describe('<Menu />', () => {
       const menu = shallowWithProps({ menuItems });
       menu.setState({ currentlyFocused: 0 });
 
-      expect(menu.find('MenuItem').props().focused).toBe(true);
+      expect(menu.find(MenuItem).props().isFocused).toBe(true);
     });
 
     it('does not flag unfocused menu items as focused', () => {
@@ -133,7 +134,7 @@ describe('<Menu />', () => {
       const menu = shallowWithProps({ menuItems });
       menu.setState({ currentlyFocused: 1 });
 
-      expect(menu.find('MenuItem').props().focused).toBe(false);
+      expect(menu.find(MenuItem).props().isFocused).toBe(false);
     });
   });
 

--- a/src/Menu/__tests__/__snapshots__/ControlledMenuItem.test.js.snap
+++ b/src/Menu/__tests__/__snapshots__/ControlledMenuItem.test.js.snap
@@ -1,30 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MenuItem /> renders a MenuItem properly 1`] = `
+exports[`<ControlledMenuItem /> renders a MenuItem properly 1`] = `
 .emotion-11 {
   box-sizing: border-box;
-  height: 40px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding: 0.75rem;
+  background: #FFFFFF;
   color: #25272D;
-  padding: 0 1rem;
-  white-space: nowrap;
+  cursor: pointer;
 }
 
-.emotion-11:hover {
-  background: #F8F9F9;
-}
-
-.emotion-11:active {
-  background: #F2F2F2;
-}
-
+.emotion-11:hover,
 .emotion-11:focus {
   background: #F8F9F9;
 }
@@ -101,11 +86,14 @@ exports[`<MenuItem /> renders a MenuItem properly 1`] = `
 <div
   aria-selected={false}
   className="emotion-11 emotion-12"
-  height="40px"
+  id="menu-item_clearance_state_ready_to_clear"
+  label="Ready to Clear"
+  name="clearance_state"
   onClick={[Function]}
   onKeyPress={[Function]}
+  onSelect={[Function]}
   role="option"
-  selected={false}
+  value="ready_to_clear"
 >
   <input
     className="emotion-0"
@@ -146,7 +134,20 @@ exports[`<MenuItem /> renders a MenuItem properly 1`] = `
 </div>
 `;
 
-exports[`<MenuItem /> renders a selected MenuItem properly 1`] = `
+exports[`<ControlledMenuItem /> renders a selected MenuItem properly 1`] = `
+.emotion-11 {
+  box-sizing: border-box;
+  padding: 0.75rem;
+  background: #FFFFFF;
+  color: #25272D;
+  cursor: pointer;
+}
+
+.emotion-11:hover,
+.emotion-11:focus {
+  background: #F8F9F9;
+}
+
 .emotion-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -216,44 +217,18 @@ exports[`<MenuItem /> renders a selected MenuItem properly 1`] = `
   line-height: 0.875rem;
 }
 
-.emotion-11 {
-  box-sizing: border-box;
-  height: 40px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #25272D;
-  padding: 0 1rem;
-  white-space: nowrap;
-  color: #0F0F10;
-  font-weight: 700;
-}
-
-.emotion-11:hover {
-  background: #F8F9F9;
-}
-
-.emotion-11:active {
-  background: #F2F2F2;
-}
-
-.emotion-11:focus {
-  background: #F8F9F9;
-}
-
 <div
-  aria-selected={true}
+  aria-selected={false}
   className="emotion-11 emotion-12"
-  height="40px"
+  id="menu-item_clearance_state_ready_to_clear"
+  label="Ready to Clear"
+  name="clearance_state"
   onClick={[Function]}
   onKeyPress={[Function]}
+  onSelect={[Function]}
   role="option"
   selected={true}
+  value="ready_to_clear"
 >
   <input
     className="emotion-0"

--- a/src/MenuItem/StyledMenuItem.js
+++ b/src/MenuItem/StyledMenuItem.js
@@ -4,50 +4,62 @@ import { css } from '@emotion/core';
 
 import Box from '../Box';
 
-const backgroundStyles = ({ isDisabled, isFocused, theme }) => {
-  if (isDisabled) {
-    return css`
-      background: ${theme.colors.monochrome.default};
-    `;
-  }
+const disabledStyles = ({ isDisabled, theme }) => {
+  if (!isDisabled) return '';
 
   return css`
-    background: ${isFocused
-      ? theme.colors.background.muted
-      : theme.colors.monochrome.default};
+    background: ${theme.colors.monochrome.white};
+    color: ${theme.colors.text.disabled};
+
+    &:hover {
+      background: ${theme.colors.monochrome.white};
+      cursor: not-allowed;
+    }
   `;
 };
 
-const cursorStyles = ({ isDisabled }) => css`
-  &:hover {
-    cursor: ${isDisabled ? 'not-allowed' : 'pointer'};
-  }
-`;
+const focusedStyles = ({ isFocused, theme }) => {
+  if (!isFocused) return '';
 
-const textStyles = ({ isDisabled, theme }) => css`
-  color: ${isDisabled ? theme.colors.text.disabled : theme.colors.text.default};
-`;
+  return css`
+    background: ${theme.colors.background.muted};
+  `;
+};
+
+const selectedStyles = ({ isSelected, theme }) => {
+  if (!isSelected) return '';
+
+  return css`
+    font-weight: ${theme.fontWeights.medium};
+  `;
+};
 
 const StyledMenuItem = styled(Box)`
-  ${backgroundStyles};
-  ${cursorStyles};
-  ${textStyles};
+  background: ${({ theme }) => theme.colors.monochrome.white};
+  color: ${({ theme }) => theme.colors.text.default};
+  cursor: pointer;
 
   &:hover,
   &:focus {
     background: ${({ theme }) => theme.colors.background.muted};
   }
+
+  ${focusedStyles};
+  ${selectedStyles};
+  ${disabledStyles};
 `;
 
 StyledMenuItem.propTypes = {
   isDisabled: PropTypes.bool,
-  isFocused: PropTypes.bool
+  isFocused: PropTypes.bool,
+  isSelected: PropTypes.bool
 };
 
 StyledMenuItem.defaultProps = {
-  p: 'small',
   isDisabled: false,
-  isFocused: false
+  isFocused: false,
+  isSelected: false,
+  p: 'small'
 };
 
 export default StyledMenuItem;

--- a/stories/menu.stories.js
+++ b/stories/menu.stories.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 
-import { Menu, Box } from '../src';
+import { Box, Grid, Heading, Icon, Menu, MenuItem, Text } from '../src';
 
 const stories = storiesOf('Menu', module);
 
@@ -125,16 +126,37 @@ const menuItems = [
   }
 ];
 
+const CustomMenuItemComponent = ({ label, secondaryLabel, ...props }) => (
+  <MenuItem {...{ label, secondaryLabel, ...props }}>
+    <Grid alignItems="center" gridGap="smaller" gridTemplateColumns="0fr 1fr">
+      <Icon name="cr-logo" />
+      <Box>
+        <Text color="inherit">{label}</Text>
+        <Text color="text.muted">{secondaryLabel}</Text>
+      </Box>
+    </Grid>
+  </MenuItem>
+);
+
+CustomMenuItemComponent.propTypes = {
+  label: PropTypes.string.isRequired,
+  secondaryLabel: PropTypes.string
+};
+
+CustomMenuItemComponent.defaultProps = {
+  secondaryLabel: undefined
+};
+
 stories.add('default', () => (
-  <div>
+  <Box as="section" p="regular">
+    <Heading.h1 mb="regular">Standard Menu</Heading.h1>
     <Menu menuItems={menuItems} />
-  </div>
+  </Box>
 ));
 
-stories.add('width-constrained', () => (
-  <div>
-    <Box maxWidth="600px">
-      <Menu menuItems={menuItems} />
-    </Box>
-  </div>
+stories.add('custom menu items', () => (
+  <Box as="section" p="regular">
+    <Heading.h1 mb="regular">Menu with Custom Menu Item</Heading.h1>
+    <Menu menuItems={menuItems} MenuItemComponent={CustomMenuItemComponent} />
+  </Box>
 ));

--- a/stories/menuItem.stories.js
+++ b/stories/menuItem.stories.js
@@ -1,141 +1,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 
-import { Box, Grid, Icon, MenuItem, Text } from '../src';
+import { Box, Heading, MenuItem, Text } from '../src';
 
 const stories = storiesOf('MenuItem', module);
-
-const menuItems = [
-  {
-    label: 'Ready to Clear (no status dot)',
-    name: 'clearance_state',
-    value: 'ready_to_clear'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label: 'Clearance Requested',
-    name: 'clearance_state',
-    value: 'clearance_requested'
-  },
-  {
-    color: 'blue',
-    iconName: 'symbol-circle',
-    label: 'Clearance Negotiation',
-    name: 'clearance_state',
-    value: 'clearance_negotation'
-  },
-  {
-    color: 'blue',
-    iconName: 'symbol-circle',
-    label: 'Copyright Approval',
-    name: 'clearance_state',
-    value: 'copyright_approval'
-  },
-  {
-    color: 'green',
-    iconName: 'symbol-circle',
-    label: 'Ready to License',
-    name: 'clearance_state',
-    value: 'ready_to_license'
-  },
-  {
-    color: 'green',
-    iconName: 'symbol-circle',
-    label: 'License Requested',
-    name: 'clearance_state',
-    value: 'license_requested'
-  },
-  {
-    color: 'green',
-    iconName: 'symbol-circle',
-    label: 'License Acquisition',
-    name: 'clearance_state',
-    value: 'license_acquisition'
-  },
-  {
-    color: 'green',
-    iconName: 'symbol-circle',
-    label: 'License Acquired',
-    name: 'clearance_state',
-    value: 'license_acquired'
-  },
-  {
-    color: 'bronze',
-    iconName: 'symbol-circle',
-    label: 'At Risk',
-    name: 'clearance_state',
-    value: 'at_risk'
-  },
-  {
-    color: 'red',
-    iconName: 'symbol-circle',
-    label: 'Clearance Cancelled',
-    name: 'clearance_state',
-    value: 'clearance_cancelled'
-  },
-  {
-    color: 'red',
-    iconName: 'symbol-circle',
-    label: 'Cannot License',
-    name: 'clearance_state',
-    value: 'cannot_license'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label: 'Primary Label',
-    secondaryLabel: 'Secondary Label',
-    name: 'menu_item',
-    value: 'with_secondary_label'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label:
-      'Looooooooooooooooooooooooooooooooooooooooooong Primary Label Without Secondary Label',
-    name: 'menu_item',
-    value: 'with_long_label_without_secondary_label'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label: 'Looooooooooooooooooooooooooooooooooooooooooong Primary Label',
-    secondaryLabel: 'Secondary Label',
-    name: 'menu_item',
-    value: 'with_long_label_with_secondary_label'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label: 'Primary Label',
-    secondaryLabel:
-      'Looooooooooooooooooooooooooooooooooooooooooooooooooong Secondary Label',
-    name: 'menu_item',
-    value: 'with_long_secondary_label'
-  },
-  {
-    color: 'grey',
-    iconName: 'symbol-circle',
-    label: 'Loooooooooooooooooooooooooooooooooooooooooooooooong Primary Label',
-    secondaryLabel:
-      'Loooooooooooooooooooooooooooooooooooooooooooooooong Secondary Label',
-    name: 'menu_item',
-    value: 'with_long_label_with_long_secondary_label'
-  }
-];
+stories.addDecorator(withKnobs);
 
 stories.add('default', () => (
-  <Box>
-    {menuItems.map(item => (
-      <MenuItem
-        onClick={() => alert(item.value)} // eslint-disable-line no-alert, no-undef
-      >
-        <Grid gridTemplateColumns="0fr 1fr" gridGap="small">
-          <Icon name={item.iconName} color={item.color} />
-          <Text>{item.label}</Text>
-        </Grid>
-      </MenuItem>
-    ))}
+  <Box as="section" p="regular">
+    <Heading.h1 mb="regular">Menu Item</Heading.h1>
+    <MenuItem
+      isDisabled={boolean('isDisabled', false)}
+      isFocused={boolean('isFocused', false)}
+      isSelected={boolean('isSelected', false)}
+    >
+      <Text color="inherit">I am a Menu Item in a Text Component!</Text>
+    </MenuItem>
   </Box>
 ));


### PR DESCRIPTION
[#167264066]

* Move existing MenuItem to ControlledMenuItem within Menu folder
* Update focused, selected to isFocused, isSelected for consistent
styling with react-select usage
* Allow for MenuItem to be completely customized via MenuItemComponent
prop on Menu component

**Existing interface**
![Screen Shot 2019-07-23 at 2 16 05 PM](https://user-images.githubusercontent.com/126970/61736603-772ff300-ad54-11e9-9c02-2144fca32679.png)

**With Custom Menu Item**
![Screen Shot 2019-07-23 at 2 16 11 PM](https://user-images.githubusercontent.com/126970/61736623-81ea8800-ad54-11e9-9223-f5a52c69cece.png)

