### PR TITLE
Display cursor at placeholder in AutoComplete

### DIFF
--- a/src/AutoComplete/StyledAutoCompletePlaceholder.js
+++ b/src/AutoComplete/StyledAutoCompletePlaceholder.js
@@ -4,7 +4,12 @@ import PropTypes from 'prop-types';
 import Flex from '../Flex';
 
 const StyledAutoCompletePlaceholder = ({ children, ...props }) => (
-  <Flex alignSelf="center" color="text.placeholder" {...props}>
+  <Flex
+    alignSelf="center"
+    color="text.placeholder"
+    position="absolute"
+    {...props}
+  >
     {children}
   </Flex>
 );

--- a/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -117,6 +117,7 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -381,6 +382,7 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -645,6 +647,7 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -909,6 +912,7 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1173,6 +1177,7 @@ exports[`<AutoComplete /> hideDropdownIndicator false renders the auto complete 
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1437,6 +1442,7 @@ exports[`<AutoComplete /> hideDropdownIndicator true renders the auto complete w
   font-family: Motiva Sans;
   color: #989A9C;
   box-sizing: border-box;
+  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;


### PR DESCRIPTION
[Finishes #167681352]

* Position the placeholder element absolutely so the cursor renders at
the start of the visual autoComplete input field

![auto-complete-cursor](https://user-images.githubusercontent.com/126970/62470301-2793f300-b768-11e9-819f-2f4cb026a815.gif)
