### PR TITLE
Set breakpoints for styled-system

### DIFF
--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -27,7 +27,12 @@ export const breakpointsMap = {
   xl: '1600px'
 };
 
+// Styled-System breakpoints
 export const breakpoints = Object.values(breakpointsMap);
+breakpoints.sm = breakpointsMap.sm;
+breakpoints.md = breakpointsMap.md;
+breakpoints.lg = breakpointsMap.lg;
+breakpoints.xl = breakpointsMap.xl;
 
 export const blues = {
   blueLighter: '#6688FF',


### PR DESCRIPTION
Styled system expects breakpoints to be specified in this way to use both array and object notation for responsive styles.

https://styled-system.com/responsive-styles