### PR TITLE
Update description lists so they can optionally render inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DescriptionList/DescriptionList.js
+++ b/src/DescriptionList/DescriptionList.js
@@ -1,5 +1,48 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
 import Box from '../Box';
 
-const DescriptionList = Box.withComponent('dl');
+const inlineStyles = ({ inline, theme }) => {
+  if (!inline) {
+    return '';
+  }
+
+  return css`
+    white-space: nowrap;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    dd {
+      display: inline;
+      margin-left: ${theme.space.smaller};
+    }
+
+    dd:after {
+      display: block;
+      content: '';
+    }
+
+    dt {
+      display: inline-block;
+      margin-bottom: ${theme.space.small};
+    }
+  `;
+};
+
+const DescriptionList = styled(Box.withComponent('dl'))`
+  ${inlineStyles};
+`;
+
+DescriptionList.propTypes = {
+  inline: PropTypes.bool
+};
+
+DescriptionList.defaultProps = {
+  ...Box.defaultProps,
+  inline: false
+};
 
 export default DescriptionList;

--- a/src/DescriptionList/__tests__/__snapshots__/DescriptionList.test.js.snap
+++ b/src/DescriptionList/__tests__/__snapshots__/DescriptionList.test.js.snap
@@ -24,7 +24,9 @@ exports[`<DescriptionList /> renders the description list properly 1`] = `
   box-sizing: border-box;
 }
 
-<DescriptionList>
+<DescriptionList
+  inline={false}
+>
   <dl
     className="emotion-12 emotion-13"
   >

--- a/stories/descriptionLists.stories.js
+++ b/stories/descriptionLists.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 
 import notes from './descriptionLists.md';
 import {
@@ -11,6 +12,7 @@ import {
 } from '../src';
 
 const stories = storiesOf('Description Lists', module);
+stories.addDecorator(withKnobs);
 
 stories.add(
   'Default',
@@ -18,7 +20,7 @@ stories.add(
     <Box as="section" p="regular">
       <Heading.h1>Description Lists</Heading.h1>
 
-      <DescriptionList>
+      <DescriptionList inline={boolean('Inline', false)}>
         <DescriptionTerm>Batman</DescriptionTerm>
         <DescriptionDetails>
           Batman is a fictional superhero appearing in American comic books


### PR DESCRIPTION
Turns out we can just set maxWidth to 100% (a reasonable default) and get the truncate-to-ellipsis that we want.