### PR TITLE
Render avatar name as-is when there are no letters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -24,6 +24,9 @@ const getInitials = name => {
   return firstInitial;
 };
 
+const getText = name =>
+  name.match(/[A-Za-z]/) ? getInitials(name).toUpperCase() : name;
+
 const Avatar = ({ name, subtle, size, baseColor: baseColorProp, ...props }) => {
   const baseColor = baseColorProp || colorForString(name, AVATAR_COLORS);
 
@@ -41,7 +44,7 @@ const Avatar = ({ name, subtle, size, baseColor: baseColorProp, ...props }) => {
       }}
     >
       <StyledAvatarText {...{ baseColor, size, subtle }}>
-        {getInitials(name).toUpperCase()}
+        {getText(name)}
       </StyledAvatarText>
     </StyledAvatar>
   );

--- a/src/Avatar/__tests__/Avatar.test.js
+++ b/src/Avatar/__tests__/Avatar.test.js
@@ -42,5 +42,13 @@ describe('<Avatar />', () => {
         expect(avatar).toHaveText('AP');
       });
     });
+
+    context('no letters in provided name', () => {
+      it('renders the name as-is', () => {
+        const avatar = shallow(<Avatar name="+36" />);
+
+        expect(avatar).toHaveText('+36');
+      });
+    });
   });
 });

--- a/stories/avatar.stories.js
+++ b/stories/avatar.stories.js
@@ -59,6 +59,11 @@ stories.add(
         subtle={boolean('subtle', false)}
         size={select('Size', sizes, 'default')}
       />
+      <Avatar
+        name={text('Avatar 10', '+42')}
+        subtle={boolean('subtle', false)}
+        size={select('Size', sizes, 'default')}
+      />
     </Flex>
   ),
   { notes: { markdown: notes } }


### PR DESCRIPTION
Numbers were being converted to "initials", which resulted in unexpected
behavior with multiple digits.

[#170564639]