### PR TITLE
add a className to the date picker input overlay, so we can target it…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DatePicker/DatePickerInputOverlay.js
+++ b/src/DatePicker/DatePickerInputOverlay.js
@@ -6,7 +6,7 @@ import DatePicker from './DatePicker';
 import PopoverContent from '../Popover/PopoverContent';
 
 const DatePickerInputOverlay = ({ classNames, children, ...props }) => (
-  <Box position="absolute" className="date-picker-input-overlay">
+  <Box position="absolute" className="arbor-date-picker-input-overlay">
     <PopoverContent className={classNames.overlayWrapper} {...props}>
       <DatePicker {...children.props} />
     </PopoverContent>

--- a/src/DatePicker/DatePickerInputOverlay.js
+++ b/src/DatePicker/DatePickerInputOverlay.js
@@ -6,7 +6,7 @@ import DatePicker from './DatePicker';
 import PopoverContent from '../Popover/PopoverContent';
 
 const DatePickerInputOverlay = ({ classNames, children, ...props }) => (
-  <Box position="absolute">
+  <Box position="absolute" className="date-picker-input-overlay">
     <PopoverContent className={classNames.overlayWrapper} {...props}>
       <DatePicker {...children.props} />
     </PopoverContent>


### PR DESCRIPTION
I did this so we can target it directly with styles, and not have to make the api even more complicated with specific one-off props that have to be drilled down the hierarchy. I also think this is better than just hard-coding a z-index in the component

Specifically, this element is absolutely positioned, and needs to be targetable to set the z-index if necessary.