### PR TITLE
update to a version of our version of react-popover which works, while not spewing deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "react-dom": "^16.12.0",
     "react-loader": "^2.4.5",
     "react-modal": "^3.8.1",
-    "react-popover": "^0.5.10",
+    "react-popover": "CatchRelease/littlebits-react-popover#master",
     "react-select": "^3.0.4",
     "react-tippy": "^1.2.3",
     "react-toastify": "^5.4.0",

--- a/src/Dropdown/__tests__/Dropdown.test.js
+++ b/src/Dropdown/__tests__/Dropdown.test.js
@@ -155,7 +155,9 @@ describe('<Dropdown />', () => {
         it('opens popover', () => {
           const instance = dropdown.instance();
 
-          const popoverOpenSpy = jest.spyOn(instance.popover.current, 'open');
+          const popoverOpenSpy = jest
+            .spyOn(instance.popover.current, 'open')
+            .mockReturnValue(null);
           instance.onKeyDown({ key: ARROW_DOWN, preventDefault: () => null });
 
           expect(popoverOpenSpy).toHaveBeenCalledTimes(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9506,10 +9506,9 @@ react-onclickoutside@^6.5.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz#9f91b5b3ed59f4d9e43fd71620dc200773a4d569"
   integrity sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA==
 
-react-popover@^0.5.10:
+react-popover@CatchRelease/littlebits-react-popover#master:
   version "0.5.10"
-  resolved "https://registry.yarnpkg.com/react-popover/-/react-popover-0.5.10.tgz#40d5e854300a96722ffc1620e49d840cb1ad5db6"
-  integrity sha512-5SYDTfncywSH00I70oHd4gFRUR8V0rJ4sRADSI/P6G0RVXp9jUgaWloJ0Bk+SFnjpLPuipTKuzQNNd2CTs5Hrw==
+  resolved "https://codeload.github.com/CatchRelease/littlebits-react-popover/tar.gz/2b4a23a618b9745093e51197f711405b95175385"
   dependencies:
     css-vendor "^0.3.1"
     debug "^2.6.8"


### PR DESCRIPTION
I don't know if we should just release our react popover version so we can consume that instead of the github repo directly. I hold little hope that the mainline project will merge any new PRs.