### PR TITLE
add support for tabs to have allow an aside node to the tab bar

### DIFF
--- a/dist/Tabs/StyledTabs.js
+++ b/dist/Tabs/StyledTabs.js
@@ -5,6 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
+var _styledBase = _interopRequireDefault(require("@emotion/styled-base"));
+
 var _Box = _interopRequireDefault(require("../Box"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
@@ -15,15 +17,30 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var StyledTabs = _Box["default"].withComponent('div', {
+function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from `css` function. It isn't supposed to be used directly (e.g. as value of the `className` prop), but rather handed to emotion so it can handle it (e.g. as value of `css` prop)."; }
+
+var StyledTabs = (
+/*#__PURE__*/
+0, _styledBase["default"])(_Box["default"].withComponent('div', {
+  target: "e8qd1cw1",
+  label: "StyledTabs"
+}), {
   target: "e8qd1cw0",
   label: "StyledTabs"
+})(process.env.NODE_ENV === "production" ? {
+  name: "x4dmss",
+  styles: "justify-content:space-between;"
+} : {
+  name: "x4dmss",
+  styles: "justify-content:space-between;",
+  map: "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9UYWJzL1N0eWxlZFRhYnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR21EIiwiZmlsZSI6Ii4uLy4uL3NyYy9UYWJzL1N0eWxlZFRhYnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCc7XG5pbXBvcnQgQm94IGZyb20gJy4uL0JveCc7XG5cbmNvbnN0IFN0eWxlZFRhYnMgPSBzdHlsZWQoQm94LndpdGhDb21wb25lbnQoJ2RpdicpKWBcbiAganVzdGlmeS1jb250ZW50OiBzcGFjZS1iZXR3ZWVuO1xuYDtcblxuU3R5bGVkVGFicy5kZWZhdWx0UHJvcHMgPSB7XG4gIC4uLkJveC5kZWZhdWx0UHJvcHMsXG4gIGJvcmRlckJvdHRvbTogJzFweCBzb2xpZCB0cmFuc3BhcmVudCcsXG4gIGJvcmRlckNvbG9yOiAnYm9yZGVyLm11dGVkJyxcbiAgZGlzcGxheTogJ2lubGluZS1mbGV4JyxcbiAgd2lkdGg6ICcxMDAlJ1xufTtcblxuZXhwb3J0IGRlZmF1bHQgU3R5bGVkVGFicztcbiJdfQ== */",
+  toString: _EMOTION_STRINGIFIED_CSS_ERROR__
 });
-
 StyledTabs.defaultProps = _objectSpread({}, _Box["default"].defaultProps, {
   borderBottom: '1px solid transparent',
   borderColor: 'border.muted',
-  display: 'inline-block'
+  display: 'inline-flex',
+  width: '100%'
 });
 var _default = StyledTabs;
 exports["default"] = _default;

--- a/dist/Tabs/Tabs.js
+++ b/dist/Tabs/Tabs.js
@@ -9,6 +9,10 @@ var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
+var _Box = _interopRequireDefault(require("../Box"));
+
+var _Flex = _interopRequireDefault(require("../Flex"));
+
 var _StyledTabs = _interopRequireDefault(require("./StyledTabs"));
 
 var _Tab = _interopRequireDefault(require("./Tab"));
@@ -101,9 +105,10 @@ function (_React$Component) {
 
       var _this$props2 = this.props,
           children = _this$props2.children,
-          props = _objectWithoutProperties(_this$props2, ["children"]);
+          tabBarAside = _this$props2.tabBarAside,
+          props = _objectWithoutProperties(_this$props2, ["children", "tabBarAside"]);
 
-      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(_StyledTabs["default"], props, children.map(function (tab) {
+      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(_StyledTabs["default"], props, _react["default"].createElement(_Box["default"], null, children.map(function (tab) {
         var _tab$props = tab.props,
             id = _tab$props.id,
             title = _tab$props.title,
@@ -126,7 +131,9 @@ function (_React$Component) {
             return _this2.handleKeyPress(key, onClick);
           }
         }, title);
-      })), this.activeTabContent);
+      })), tabBarAside && _react["default"].createElement(_Flex["default"], {
+        alignItems: "center"
+      }, tabBarAside)), this.activeTabContent);
     }
   }, {
     key: "activeTab",
@@ -167,11 +174,13 @@ function (_React$Component) {
 Tabs.propTypes = {
   activeTabId: _propTypes["default"].string,
   defaultTabId: _propTypes["default"].string,
-  children: _propTypes["default"].oneOfType([_propTypes["default"].arrayOf(_Tab["default"]), _propTypes["default"].objectOf(_Tab["default"])]).isRequired
+  children: _propTypes["default"].oneOfType([_propTypes["default"].arrayOf(_Tab["default"]), _propTypes["default"].objectOf(_Tab["default"])]).isRequired,
+  tabBarAside: _propTypes["default"].node
 };
 Tabs.defaultProps = {
   activeTabId: undefined,
-  defaultTabId: undefined
+  defaultTabId: undefined,
+  tabBarAside: undefined
 };
 var _default = Tabs;
 exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.88.1",
+  "version": "0.89.0",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Tabs/StyledTabs.js
+++ b/src/Tabs/StyledTabs.js
@@ -1,12 +1,16 @@
+import styled from '@emotion/styled';
 import Box from '../Box';
 
-const StyledTabs = Box.withComponent('div');
+const StyledTabs = styled(Box.withComponent('div'))`
+  justify-content: space-between;
+`;
 
 StyledTabs.defaultProps = {
   ...Box.defaultProps,
   borderBottom: '1px solid transparent',
   borderColor: 'border.muted',
-  display: 'inline-block'
+  display: 'inline-flex',
+  width: '100%'
 };
 
 export default StyledTabs;

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Box from '../Box';
+import Flex from '../Flex';
 import StyledTabs from './StyledTabs';
 import Tab from './Tab';
 import { ENTER_KEY, SPACEBAR } from '../constants';
@@ -69,30 +71,33 @@ class Tabs extends React.Component {
 
   render() {
     const { activeTabId } = this;
-    const { children, ...props } = this.props;
+    const { children, tabBarAside, ...props } = this.props;
 
     return (
       <>
         <StyledTabs {...props}>
-          {children.map(tab => {
-            const { id, title, onClick: originalOnClick } = tab.props;
-            const active = activeTabId === id;
-            const tabContentId = getTabContentId(tab);
-            const onClick = () => this.handleTabClick(tab, originalOnClick);
+          <Box>
+            {children.map(tab => {
+              const { id, title, onClick: originalOnClick } = tab.props;
+              const active = activeTabId === id;
+              const tabContentId = getTabContentId(tab);
+              const onClick = () => this.handleTabClick(tab, originalOnClick);
 
-            return React.cloneElement(
-              tab,
-              {
-                'aria-controls': tabContentId,
-                'aria-selected': active ? 'true' : 'false',
-                active,
-                key: id,
-                onClick,
-                onKeyPress: ({ key }) => this.handleKeyPress(key, onClick)
-              },
-              title
-            );
-          })}
+              return React.cloneElement(
+                tab,
+                {
+                  'aria-controls': tabContentId,
+                  'aria-selected': active ? 'true' : 'false',
+                  active,
+                  key: id,
+                  onClick,
+                  onKeyPress: ({ key }) => this.handleKeyPress(key, onClick)
+                },
+                title
+              );
+            })}
+          </Box>
+          {tabBarAside && <Flex alignItems="center">{tabBarAside}</Flex>}
         </StyledTabs>
         {this.activeTabContent}
       </>
@@ -106,12 +111,14 @@ Tabs.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(Tab),
     PropTypes.objectOf(Tab)
-  ]).isRequired
+  ]).isRequired,
+  tabBarAside: PropTypes.node
 };
 
 Tabs.defaultProps = {
   activeTabId: undefined,
-  defaultTabId: undefined
+  defaultTabId: undefined,
+  tabBarAside: undefined
 };
 
 export default Tabs;

--- a/stories/tabs.stories.js
+++ b/stories/tabs.stories.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 
 import notes from './tabs.md';
 import { Box, Heading, Icon, Tab, Tabs } from '../src';
 
 const stories = storiesOf('Tabs', module);
+stories.addDecorator(withKnobs);
 
 const titleAsComponent = (
   <>
@@ -12,6 +14,8 @@ const titleAsComponent = (
     <Icon ml="smaller" name="cr-logo" />
   </>
 );
+
+const aside = <Box>Hello nice friends!</Box>;
 
 const alertTabOnclick = activateTab => {
   alert('tab clicked!'); // eslint-disable-line no-alert, no-undef
@@ -24,7 +28,7 @@ stories.add(
     <Box as="section" p="regular">
       <Heading.h1>Tabs</Heading.h1>
 
-      <Tabs defaultTabId="tab-2">
+      <Tabs defaultTabId="tab-2" tabBarAside={boolean('aside', false) && aside}>
         <Tab id="tab-1" title="Tab 1">
           <Box bg="palette.blue.lighter" p="largest">
             Tab 1 Content


### PR DESCRIPTION
This is needed to place the filter bar on the same line as the tabs themselves

![Screenshot from 2020-02-14 16-54-48](https://user-images.githubusercontent.com/41678/74578622-bc16b380-4f4a-11ea-9cf6-b597f74b27c6.png)

