### PR TITLE
Export the autocomplete subcomponents, so we can tweak their styles without fully copy-pasting them

### DIFF
--- a/dist/AutoComplete/StyledAutoComplete.js
+++ b/dist/AutoComplete/StyledAutoComplete.js
@@ -21,31 +21,7 @@ var _emotionTheming = require("emotion-theming");
 
 var _buildReactSelectThemeOverrides = _interopRequireDefault(require("./buildReactSelectThemeOverrides"));
 
-var _StyledAutoCompleteClearIndicator = _interopRequireDefault(require("./StyledAutoCompleteClearIndicator"));
-
-var _StyledAutoCompleteContainer = _interopRequireDefault(require("./StyledAutoCompleteContainer"));
-
-var _StyledAutoCompleteControl = _interopRequireDefault(require("./StyledAutoCompleteControl"));
-
-var _StyledAutoCompleteDropdownIndicator = _interopRequireDefault(require("./StyledAutoCompleteDropdownIndicator"));
-
-var _StyledAutoCompleteIndicatorsContainer = _interopRequireDefault(require("./StyledAutoCompleteIndicatorsContainer"));
-
-var _StyledAutoCompleteInput = _interopRequireDefault(require("./StyledAutoCompleteInput"));
-
-var _StyledAutoCompleteMenu = _interopRequireDefault(require("./StyledAutoCompleteMenu"));
-
-var _StyledAutoCompleteMenuList = _interopRequireDefault(require("./StyledAutoCompleteMenuList"));
-
-var _StyledAutoCompleteMultiValue = _interopRequireDefault(require("./StyledAutoCompleteMultiValue"));
-
-var _StyledAutoCompleteNoOptionsMessage = _interopRequireDefault(require("./StyledAutoCompleteNoOptionsMessage"));
-
-var _StyledAutoCompleteOption = _interopRequireDefault(require("./StyledAutoCompleteOption"));
-
-var _StyledAutoCompletePlaceholder = _interopRequireDefault(require("./StyledAutoCompletePlaceholder"));
-
-var _StyledAutoCompleteValueContainer = _interopRequireDefault(require("./StyledAutoCompleteValueContainer"));
+var _styledAutoCompleteComponents = require("./styledAutoCompleteComponents");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -58,22 +34,6 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
-var styledComponents = {
-  ClearIndicator: _StyledAutoCompleteClearIndicator["default"],
-  Container: _StyledAutoCompleteContainer["default"],
-  Control: _StyledAutoCompleteControl["default"],
-  DropdownIndicator: _StyledAutoCompleteDropdownIndicator["default"],
-  IndicatorsContainer: _StyledAutoCompleteIndicatorsContainer["default"],
-  Input: _StyledAutoCompleteInput["default"],
-  Menu: _StyledAutoCompleteMenu["default"],
-  MenuList: _StyledAutoCompleteMenuList["default"],
-  MultiValue: _StyledAutoCompleteMultiValue["default"],
-  NoOptionsMessage: _StyledAutoCompleteNoOptionsMessage["default"],
-  Placeholder: _StyledAutoCompletePlaceholder["default"],
-  Option: _StyledAutoCompleteOption["default"],
-  ValueContainer: _StyledAutoCompleteValueContainer["default"]
-};
 
 var getReactSelectComponent = function getReactSelectComponent(variant) {
   switch (variant) {
@@ -100,7 +60,7 @@ var StyledAutoComplete = function StyledAutoComplete(_ref) {
   var SelectComponent = getReactSelectComponent(variant);
 
   var reactSelectProps = _objectSpread({
-    components: _objectSpread({}, styledComponents, {}, components),
+    components: _objectSpread({}, _styledAutoCompleteComponents.subComponents, {}, components),
     theme: function theme(reactSelectTheme) {
       return _objectSpread({}, reactSelectTheme, {}, (0, _buildReactSelectThemeOverrides["default"])(_theme), {}, _theme);
     }

--- a/dist/AutoComplete/StyledAutoCompleteClearIndicator.js
+++ b/dist/AutoComplete/StyledAutoCompleteClearIndicator.js
@@ -27,21 +27,18 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 
 var StyledAutoCompleteClearIndicator = function StyledAutoCompleteClearIndicator(_ref) {
   var innerProps = _ref.innerProps,
-      innerRef = _ref.innerRef,
-      props = _objectWithoutProperties(_ref, ["innerProps", "innerRef"]);
+      props = _objectWithoutProperties(_ref, ["innerProps"]);
 
   return _react["default"].createElement(_Icon["default"], _extends({
     "aria-label": "clear selection",
     fontSize: "size4",
-    name: "cross",
-    ref: innerRef
+    name: "cross"
   }, _objectSpread({}, innerProps, {}, props)));
 };
 
 StyledAutoCompleteClearIndicator.propTypes = {
-  innerProps: _propTypes["default"].object.isRequired,
-  // eslint-disable-line react/forbid-prop-types
-  innerRef: _propTypes["default"].func.isRequired
+  innerProps: _propTypes["default"].object.isRequired // eslint-disable-line react/forbid-prop-types
+
 };
 var _default = StyledAutoCompleteClearIndicator;
 exports["default"] = _default;

--- a/dist/AutoComplete/index.js
+++ b/dist/AutoComplete/index.js
@@ -9,7 +9,15 @@ Object.defineProperty(exports, "default", {
     return _AutoComplete["default"];
   }
 });
+Object.defineProperty(exports, "styledAutoCompleteComponents", {
+  enumerable: true,
+  get: function get() {
+    return _styledAutoCompleteComponents["default"];
+  }
+});
 
 var _AutoComplete = _interopRequireDefault(require("./AutoComplete"));
+
+var _styledAutoCompleteComponents = _interopRequireDefault(require("./styledAutoCompleteComponents"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }

--- a/dist/AutoComplete/styledAutoCompleteComponents.js
+++ b/dist/AutoComplete/styledAutoCompleteComponents.js
@@ -1,0 +1,65 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = exports.subComponents = void 0;
+
+var _StyledAutoComplete = _interopRequireDefault(require("./StyledAutoComplete"));
+
+var _StyledAutoCompleteClearIndicator = _interopRequireDefault(require("./StyledAutoCompleteClearIndicator"));
+
+var _StyledAutoCompleteContainer = _interopRequireDefault(require("./StyledAutoCompleteContainer"));
+
+var _StyledAutoCompleteControl = _interopRequireDefault(require("./StyledAutoCompleteControl"));
+
+var _StyledAutoCompleteDropdownIndicator = _interopRequireDefault(require("./StyledAutoCompleteDropdownIndicator"));
+
+var _StyledAutoCompleteIndicatorsContainer = _interopRequireDefault(require("./StyledAutoCompleteIndicatorsContainer"));
+
+var _StyledAutoCompleteInput = _interopRequireDefault(require("./StyledAutoCompleteInput"));
+
+var _StyledAutoCompleteMenu = _interopRequireDefault(require("./StyledAutoCompleteMenu"));
+
+var _StyledAutoCompleteMenuList = _interopRequireDefault(require("./StyledAutoCompleteMenuList"));
+
+var _StyledAutoCompleteMultiValue = _interopRequireDefault(require("./StyledAutoCompleteMultiValue"));
+
+var _StyledAutoCompleteNoOptionsMessage = _interopRequireDefault(require("./StyledAutoCompleteNoOptionsMessage"));
+
+var _StyledAutoCompletePlaceholder = _interopRequireDefault(require("./StyledAutoCompletePlaceholder"));
+
+var _StyledAutoCompleteOption = _interopRequireDefault(require("./StyledAutoCompleteOption"));
+
+var _StyledAutoCompleteValueContainer = _interopRequireDefault(require("./StyledAutoCompleteValueContainer"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var subComponents = {
+  ClearIndicator: _StyledAutoCompleteClearIndicator["default"],
+  Container: _StyledAutoCompleteContainer["default"],
+  Control: _StyledAutoCompleteControl["default"],
+  DropdownIndicator: _StyledAutoCompleteDropdownIndicator["default"],
+  IndicatorsContainer: _StyledAutoCompleteIndicatorsContainer["default"],
+  Input: _StyledAutoCompleteInput["default"],
+  Menu: _StyledAutoCompleteMenu["default"],
+  MenuList: _StyledAutoCompleteMenuList["default"],
+  MultiValue: _StyledAutoCompleteMultiValue["default"],
+  NoOptionsMessage: _StyledAutoCompleteNoOptionsMessage["default"],
+  Placeholder: _StyledAutoCompletePlaceholder["default"],
+  Option: _StyledAutoCompleteOption["default"],
+  ValueContainer: _StyledAutoCompleteValueContainer["default"]
+};
+exports.subComponents = subComponents;
+
+var _default = _objectSpread({}, subComponents, {
+  StyledAutoComplete: _StyledAutoComplete["default"]
+});
+
+exports["default"] = _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,6 +7,7 @@ var _exportNames = {
   theme: true,
   AccordionSection: true,
   AutoComplete: true,
+  styledAutoCompleteComponents: true,
   Avatar: true,
   Badge: true,
   Box: true,
@@ -62,6 +63,12 @@ Object.defineProperty(exports, "AutoComplete", {
   enumerable: true,
   get: function get() {
     return _AutoComplete["default"];
+  }
+});
+Object.defineProperty(exports, "styledAutoCompleteComponents", {
+  enumerable: true,
+  get: function get() {
+    return _AutoComplete.styledAutoCompleteComponents;
   }
 });
 Object.defineProperty(exports, "Avatar", {
@@ -321,7 +328,7 @@ Object.keys(_Alert).forEach(function (key) {
   });
 });
 
-var _AutoComplete = _interopRequireDefault(require("./AutoComplete"));
+var _AutoComplete = _interopRequireWildcard(require("./AutoComplete"));
 
 var _Avatar = _interopRequireDefault(require("./Avatar"));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.89.0",
+  "version": "0.89.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/AutoComplete/StyledAutoComplete.js
+++ b/src/AutoComplete/StyledAutoComplete.js
@@ -7,36 +7,7 @@ import PropTypes from 'prop-types';
 import { withTheme } from 'emotion-theming';
 
 import buildReactSelectThemeOverrides from './buildReactSelectThemeOverrides';
-
-import StyledAutoCompleteClearIndicator from './StyledAutoCompleteClearIndicator';
-import StyledAutoCompleteContainer from './StyledAutoCompleteContainer';
-import StyledAutoCompleteControl from './StyledAutoCompleteControl';
-import StyledAutoCompleteDropdownIndicator from './StyledAutoCompleteDropdownIndicator';
-import StyledAutoCompleteIndicatorsContainer from './StyledAutoCompleteIndicatorsContainer';
-import StyledAutoCompleteInput from './StyledAutoCompleteInput';
-import StyledAutoCompleteMenu from './StyledAutoCompleteMenu';
-import StyledAutoCompleteMenuList from './StyledAutoCompleteMenuList';
-import StyledAutoCompleteMultiValue from './StyledAutoCompleteMultiValue';
-import StyledAutoCompleteNoOptionsMessage from './StyledAutoCompleteNoOptionsMessage';
-import StyledAutoCompleteOption from './StyledAutoCompleteOption';
-import StyledAutoCompletePlaceholder from './StyledAutoCompletePlaceholder';
-import StyledAutoCompleteValueContainer from './StyledAutoCompleteValueContainer';
-
-const styledComponents = {
-  ClearIndicator: StyledAutoCompleteClearIndicator,
-  Container: StyledAutoCompleteContainer,
-  Control: StyledAutoCompleteControl,
-  DropdownIndicator: StyledAutoCompleteDropdownIndicator,
-  IndicatorsContainer: StyledAutoCompleteIndicatorsContainer,
-  Input: StyledAutoCompleteInput,
-  Menu: StyledAutoCompleteMenu,
-  MenuList: StyledAutoCompleteMenuList,
-  MultiValue: StyledAutoCompleteMultiValue,
-  NoOptionsMessage: StyledAutoCompleteNoOptionsMessage,
-  Placeholder: StyledAutoCompletePlaceholder,
-  Option: StyledAutoCompleteOption,
-  ValueContainer: StyledAutoCompleteValueContainer
-};
+import { subComponents as styledComponents } from './styledAutoCompleteComponents';
 
 const getReactSelectComponent = variant => {
   switch (variant) {

--- a/src/AutoComplete/StyledAutoCompleteClearIndicator.js
+++ b/src/AutoComplete/StyledAutoCompleteClearIndicator.js
@@ -3,23 +3,17 @@ import PropTypes from 'prop-types';
 
 import Icon from '../Icon';
 
-const StyledAutoCompleteClearIndicator = ({
-  innerProps,
-  innerRef,
-  ...props
-}) => (
+const StyledAutoCompleteClearIndicator = ({ innerProps, ...props }) => (
   <Icon
     aria-label="clear selection"
     fontSize="size4"
     name="cross"
-    ref={innerRef}
     {...{ ...innerProps, ...props }}
   />
 );
 
 StyledAutoCompleteClearIndicator.propTypes = {
-  innerProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  innerRef: PropTypes.func.isRequired
+  innerProps: PropTypes.object.isRequired // eslint-disable-line react/forbid-prop-types
 };
 
 export default StyledAutoCompleteClearIndicator;

--- a/src/AutoComplete/index.js
+++ b/src/AutoComplete/index.js
@@ -1,1 +1,4 @@
 export { default } from './AutoComplete';
+export {
+  default as styledAutoCompleteComponents
+} from './styledAutoCompleteComponents';

--- a/src/AutoComplete/styledAutoCompleteComponents.js
+++ b/src/AutoComplete/styledAutoCompleteComponents.js
@@ -1,0 +1,35 @@
+import StyledAutoComplete from './StyledAutoComplete';
+import StyledAutoCompleteClearIndicator from './StyledAutoCompleteClearIndicator';
+import StyledAutoCompleteContainer from './StyledAutoCompleteContainer';
+import StyledAutoCompleteControl from './StyledAutoCompleteControl';
+import StyledAutoCompleteDropdownIndicator from './StyledAutoCompleteDropdownIndicator';
+import StyledAutoCompleteIndicatorsContainer from './StyledAutoCompleteIndicatorsContainer';
+import StyledAutoCompleteInput from './StyledAutoCompleteInput';
+import StyledAutoCompleteMenu from './StyledAutoCompleteMenu';
+import StyledAutoCompleteMenuList from './StyledAutoCompleteMenuList';
+import StyledAutoCompleteMultiValue from './StyledAutoCompleteMultiValue';
+import StyledAutoCompleteNoOptionsMessage from './StyledAutoCompleteNoOptionsMessage';
+import StyledAutoCompletePlaceholder from './StyledAutoCompletePlaceholder';
+import StyledAutoCompleteOption from './StyledAutoCompleteOption';
+import StyledAutoCompleteValueContainer from './StyledAutoCompleteValueContainer';
+
+export const subComponents = {
+  ClearIndicator: StyledAutoCompleteClearIndicator,
+  Container: StyledAutoCompleteContainer,
+  Control: StyledAutoCompleteControl,
+  DropdownIndicator: StyledAutoCompleteDropdownIndicator,
+  IndicatorsContainer: StyledAutoCompleteIndicatorsContainer,
+  Input: StyledAutoCompleteInput,
+  Menu: StyledAutoCompleteMenu,
+  MenuList: StyledAutoCompleteMenuList,
+  MultiValue: StyledAutoCompleteMultiValue,
+  NoOptionsMessage: StyledAutoCompleteNoOptionsMessage,
+  Placeholder: StyledAutoCompletePlaceholder,
+  Option: StyledAutoCompleteOption,
+  ValueContainer: StyledAutoCompleteValueContainer
+};
+
+export default {
+  ...subComponents,
+  StyledAutoComplete
+};

--- a/src/index.js
+++ b/src/index.js
@@ -43,4 +43,5 @@ export { default as Textarea } from './Textarea';
 export * from './Toast';
 export { default as Tooltip } from './Tooltip';
 export { default as reset } from './reset';
+export { styledAutoCompleteComponents } from './AutoComplete';
 export { default as theme } from './theme';


### PR DESCRIPTION
I've had to replace a number of components as part of https://www.pivotaltracker.com/story/show/171095538. Doing this means we can use styled() without copy/pasting the entire rest of the component