### PR TITLE
update Text to accept a width prop, since so many things are built ontop of it (e.g. Links), and it already handles maxWidth and minWidth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Alert/__tests__/__snapshots__/CardAlert.test.js.snap
+++ b/src/Alert/__tests__/__snapshots__/CardAlert.test.js.snap
@@ -32,6 +32,7 @@ exports[`<CardAlert /> property renders a banner alert with danger intent 1`] = 
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -96,6 +97,7 @@ exports[`<CardAlert /> property renders a banner alert with info intent 1`] = `
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -162,6 +164,7 @@ exports[`<CardAlert /> property renders a banner alert with no intent 1`] = `
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -244,6 +247,7 @@ exports[`<CardAlert /> property renders a banner alert with success intent 1`] =
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -322,6 +326,7 @@ exports[`<CardAlert /> property renders a banner alert with warning intent 1`] =
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -411,6 +416,7 @@ exports[`<CardAlert /> with details property renders a banner alert, with danger
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -505,6 +511,7 @@ exports[`<CardAlert /> with details property renders a banner alert, with info i
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -581,6 +588,7 @@ exports[`<CardAlert /> with details property renders a banner alert, with no int
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -668,6 +676,7 @@ exports[`<CardAlert /> with details property renders a banner alert, with succes
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -762,6 +771,7 @@ exports[`<CardAlert /> with details property renders a banner alert, with warnin
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -942,6 +952,7 @@ exports[`<CardAlert /> with onClose property renders a banner alert, with danger
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -1126,6 +1137,7 @@ exports[`<CardAlert /> with onClose property renders a banner alert, with info i
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -1215,6 +1227,7 @@ exports[`<CardAlert /> with onClose property renders a banner alert, with no int
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -1520,6 +1533,7 @@ exports[`<CardAlert /> with onClose property renders a banner alert, with succes
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -1718,6 +1732,7 @@ exports[`<CardAlert /> with onClose property renders a banner alert, with warnin
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;

--- a/src/Alert/__tests__/__snapshots__/PaneAlert.test.js.snap
+++ b/src/Alert/__tests__/__snapshots__/PaneAlert.test.js.snap
@@ -31,6 +31,7 @@ exports[`<PaneAlert /> property renders a banner alert with danger intent 1`] = 
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -93,6 +94,7 @@ exports[`<PaneAlert /> property renders a banner alert with info intent 1`] = `
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -157,6 +159,7 @@ exports[`<PaneAlert /> property renders a banner alert with no intent 1`] = `
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);
@@ -237,6 +240,7 @@ exports[`<PaneAlert /> property renders a banner alert with success intent 1`] =
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -313,6 +317,7 @@ exports[`<PaneAlert /> property renders a banner alert with warning intent 1`] =
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -396,6 +401,7 @@ exports[`<PaneAlert /> with details property renders a banner alert, with danger
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -475,6 +481,7 @@ exports[`<PaneAlert /> with details property renders a banner alert, with info i
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -549,6 +556,7 @@ exports[`<PaneAlert /> with details property renders a banner alert, with no int
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);
@@ -650,6 +658,7 @@ exports[`<PaneAlert /> with details property renders a banner alert, with succes
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -743,6 +752,7 @@ exports[`<PaneAlert /> with details property renders a banner alert, with warnin
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -926,6 +936,7 @@ exports[`<PaneAlert /> with onClose property renders a banner alert, with danger
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -1108,6 +1119,7 @@ exports[`<PaneAlert /> with onClose property renders a banner alert, with info i
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -1195,6 +1207,7 @@ exports[`<PaneAlert /> with onClose property renders a banner alert, with no int
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);
@@ -1498,6 +1511,7 @@ exports[`<PaneAlert /> with onClose property renders a banner alert, with succes
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -1694,6 +1708,7 @@ exports[`<PaneAlert /> with onClose property renders a banner alert, with warnin
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;

--- a/src/Alert/__tests__/__snapshots__/ToastAlert.test.js.snap
+++ b/src/Alert/__tests__/__snapshots__/ToastAlert.test.js.snap
@@ -32,6 +32,7 @@ exports[`<ToastAlert /> property renders a banner alert with danger intent 1`] =
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -96,6 +97,7 @@ exports[`<ToastAlert /> property renders a banner alert with info intent 1`] = `
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -162,6 +164,7 @@ exports[`<ToastAlert /> property renders a banner alert with no intent 1`] = `
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -244,6 +247,7 @@ exports[`<ToastAlert /> property renders a banner alert with success intent 1`] 
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -322,6 +326,7 @@ exports[`<ToastAlert /> property renders a banner alert with warning intent 1`] 
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -411,6 +416,7 @@ exports[`<ToastAlert /> with details property renders a banner alert, with dange
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -505,6 +511,7 @@ exports[`<ToastAlert /> with details property renders a banner alert, with info 
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -581,6 +588,7 @@ exports[`<ToastAlert /> with details property renders a banner alert, with no in
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -668,6 +676,7 @@ exports[`<ToastAlert /> with details property renders a banner alert, with succe
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -762,6 +771,7 @@ exports[`<ToastAlert /> with details property renders a banner alert, with warni
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;
@@ -942,6 +952,7 @@ exports[`<ToastAlert /> with onClose property renders a banner alert, with dange
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #D93838;
@@ -1126,6 +1137,7 @@ exports[`<ToastAlert /> with onClose property renders a banner alert, with info 
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #4263EB;
@@ -1215,6 +1227,7 @@ exports[`<ToastAlert /> with onClose property renders a banner alert, with no in
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-color: intent.undefined.default;
   border-radius: 6px;
@@ -1520,6 +1533,7 @@ exports[`<ToastAlert /> with onClose property renders a banner alert, with succe
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #29863A;
@@ -1718,6 +1732,7 @@ exports[`<ToastAlert /> with onClose property renders a banner alert, with warni
   background-color: #FFFFFF;
   overflow: hidden;
   text-align: center;
+  width: 100%;
   box-sizing: border-box;
   border-left: 3px solid;
   border-color: #C55205;

--- a/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<Avatar /> renders properly 1`] = `
 .emotion-2 {
   font-family: Motiva Sans;
+  width: 24px;
   box-sizing: border-box;
   border: 1px solid;
   border-radius: 50%;

--- a/src/Avatar/__tests__/__snapshots__/StyledAvatar.test.js.snap
+++ b/src/Avatar/__tests__/__snapshots__/StyledAvatar.test.js.snap
@@ -4,6 +4,7 @@ exports[`<StyledAvatar /> sizes renders default properly 1`] = `
 .emotion-0 {
   font-family: Motiva Sans;
   background-color: #29863A;
+  width: 24px;
   box-sizing: border-box;
   border: 1px solid;
   border-color: #29863A;
@@ -27,6 +28,7 @@ exports[`<StyledAvatar /> sizes renders medium properly 1`] = `
 .emotion-0 {
   font-family: Motiva Sans;
   background-color: #29863A;
+  width: 32px;
   box-sizing: border-box;
   border: 1px solid;
   border-color: #29863A;

--- a/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -5,6 +5,7 @@ exports[`<Card /> renders a Card properly 1`] = `
   font-family: Motiva Sans;
   background-color: #FFFFFF;
   overflow: hidden;
+  width: 100%;
   box-sizing: border-box;
   border-radius: 6px;
   box-shadow: 0 0 1px rgba(37,39,45,0.47);

--- a/src/Masonry/__tests__/__snapshots__/Masonry.test.js.snap
+++ b/src/Masonry/__tests__/__snapshots__/Masonry.test.js.snap
@@ -21,6 +21,7 @@ exports[`<Masonry /> renders properly 1`] = `
 .emotion-0 {
   font-family: Motiva Sans;
   margin-bottom: 1rem;
+  width: 100%;
   box-sizing: border-box;
   display: block;
   width: 100%;

--- a/src/Menu/__tests__/__snapshots__/ControlledMenuItem.test.js.snap
+++ b/src/Menu/__tests__/__snapshots__/ControlledMenuItem.test.js.snap
@@ -33,6 +33,7 @@ exports[`<ControlledMenuItem /> renders a MenuItem properly 1`] = `
 
 .emotion-9 {
   font-family: Motiva Sans;
+  width: 100%;
   box-sizing: border-box;
   width: 100%;
   display: -webkit-box;
@@ -175,6 +176,7 @@ exports[`<ControlledMenuItem /> renders a selected MenuItem properly 1`] = `
 
 .emotion-9 {
   font-family: Motiva Sans;
+  width: 100%;
   box-sizing: border-box;
   width: 100%;
   display: -webkit-box;

--- a/src/ProgressBar/__tests__/__snapshots__/ProgressBar.test.js.snap
+++ b/src/ProgressBar/__tests__/__snapshots__/ProgressBar.test.js.snap
@@ -99,6 +99,8 @@ exports[`<ProgressBar /> renders the progress bar properly 1`] = `
                   ";",
                   [Function],
                   ";",
+                  [Function],
+                  ";",
                   "label:Box;",
                   "box-sizing:border-box;",
                   [Function],
@@ -561,6 +563,8 @@ exports[`<ProgressBar /> renders the progress bar properly at 100% with an icon 
                 "__emotion_styles": Array [
                   "label:Box;",
                   "label:Text;",
+                  [Function],
+                  ";",
                   [Function],
                   ";",
                   [Function],

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -10,7 +10,8 @@ import {
   minWidth,
   overflow,
   space,
-  textAlign
+  textAlign,
+  width
 } from 'styled-system';
 
 import textTransform from '../utils/textTransform';
@@ -36,6 +37,7 @@ const Text = styled.p`
   ${textTransform};
   ${textOverflow};
   ${whiteSpace};
+  ${width};
 `;
 
 Text.propTypes = {
@@ -50,7 +52,8 @@ Text.propTypes = {
   ...textAlign.propTypes,
   ...textTransform.propTypes,
   ...textOverflow.propTypes,
-  ...whiteSpace.propTypes
+  ...whiteSpace.propTypes,
+  ...width.propTypes
 };
 
 Text.defaultProps = {


### PR DESCRIPTION
The problem this is intended to solve, is for links that wrap buttons, where the button needs to appear at different sizes depending on the css breakpoint. Right now, the wrapping link is controlling that unnecessarily, and because Link is built on Text, and Text did not support the `width` prop, we had to fallback to `css()`, which doesn't have any sort of clean breakpoint integration that styled-system props do.

additionally, text already supprorts maxWidth and minWidth props