### PR TITLE
Support passing contentProps through Popover

### DIFF
--- a/dist/Popover/Popover.js
+++ b/dist/Popover/Popover.js
@@ -142,12 +142,13 @@ function (_React$Component) {
       var _this$props = this.props,
           children = _this$props.children,
           content = _this$props.content,
+          contentProps = _this$props.contentProps,
           preferPlace = _this$props.preferPlace,
           place = _this$props.place,
-          popoverProps = _objectWithoutProperties(_this$props, ["children", "content", "preferPlace", "place"]);
+          popoverProps = _objectWithoutProperties(_this$props, ["children", "content", "contentProps", "preferPlace", "place"]);
 
       var isOpen = this.state.isOpen;
-      var styledContent = (0, _core.jsx)(_PopoverContent["default"], null, content);
+      var styledContent = (0, _core.jsx)(_PopoverContent["default"], contentProps, content);
 
       var trigger = _react["default"].cloneElement(children, {
         onClick: this.toggle
@@ -173,6 +174,12 @@ Popover.propTypes = {
    * Content to display within the Popover
    */
   content: _propTypes["default"].node.isRequired,
+
+  /**
+   * Props to be passed to the PopoverContent component
+   */
+  contentProps: _propTypes["default"].object,
+  // eslint-disable-line react/forbid-prop-types
 
   /**
    * The trigger which will open the popover when it is clicked. By default,
@@ -206,6 +213,7 @@ Popover.propTypes = {
   place: _propTypes["default"].oneOf(['above', 'right', 'below', 'left', 'row', 'column', 'start', 'end'])
 };
 Popover.defaultProps = {
+  contentProps: {},
   preferPlace: 'below',
   place: 'column',
   onOpen: function onOpen() {

--- a/dist/Popover/PopoverContent.js
+++ b/dist/Popover/PopoverContent.js
@@ -20,6 +20,9 @@ var PopoverContent = (
   return props.theme.colors.monochrome.white;
 }, ";box-shadow:", function (props) {
   return props.theme.shadows.elevation2;
-}, ";min-height:40px;min-width:160px;overflow:hidden;" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9Qb3BvdmVyL1BvcG92ZXJDb250ZW50LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUltQyIsImZpbGUiOiIuLi8uLi9zcmMvUG9wb3Zlci9Qb3BvdmVyQ29udGVudC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJztcblxuaW1wb3J0IENhcmQgZnJvbSAnLi4vQ2FyZCc7XG5cbmNvbnN0IFBvcG92ZXJDb250ZW50ID0gc3R5bGVkKENhcmQpYFxuICBiYWNrZ3JvdW5kOiAke3Byb3BzID0+IHByb3BzLnRoZW1lLmNvbG9ycy5tb25vY2hyb21lLndoaXRlfTtcbiAgYm94LXNoYWRvdzogJHtwcm9wcyA9PiBwcm9wcy50aGVtZS5zaGFkb3dzLmVsZXZhdGlvbjJ9O1xuICBtaW4taGVpZ2h0OiA0MHB4O1xuICBtaW4td2lkdGg6IDE2MHB4O1xuICBvdmVyZmxvdzogaGlkZGVuO1xuYDtcblxuZXhwb3J0IGRlZmF1bHQgUG9wb3ZlckNvbnRlbnQ7XG4iXX0= */"));
+}, ";min-height:40px;min-width:160px;" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9Qb3BvdmVyL1BvcG92ZXJDb250ZW50LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUltQyIsImZpbGUiOiIuLi8uLi9zcmMvUG9wb3Zlci9Qb3BvdmVyQ29udGVudC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJztcblxuaW1wb3J0IENhcmQgZnJvbSAnLi4vQ2FyZCc7XG5cbmNvbnN0IFBvcG92ZXJDb250ZW50ID0gc3R5bGVkKENhcmQpYFxuICBiYWNrZ3JvdW5kOiAke3Byb3BzID0+IHByb3BzLnRoZW1lLmNvbG9ycy5tb25vY2hyb21lLndoaXRlfTtcbiAgYm94LXNoYWRvdzogJHtwcm9wcyA9PiBwcm9wcy50aGVtZS5zaGFkb3dzLmVsZXZhdGlvbjJ9O1xuICBtaW4taGVpZ2h0OiA0MHB4O1xuICBtaW4td2lkdGg6IDE2MHB4O1xuYDtcblxuUG9wb3ZlckNvbnRlbnQuZGVmYXVsdFByb3BzID0ge1xuICBvdmVyZmxvdzogJ2hpZGRlbidcbn07XG5cbmV4cG9ydCBkZWZhdWx0IFBvcG92ZXJDb250ZW50O1xuIl19 */"));
+PopoverContent.defaultProps = {
+  overflow: 'hidden'
+};
 var _default = PopoverContent;
 exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.90.0",
+  "version": "0.90.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -92,13 +92,16 @@ class Popover extends React.Component {
     const {
       children,
       content,
+      contentProps,
       preferPlace,
       place,
       ...popoverProps
     } = this.props;
     const { isOpen } = this.state;
 
-    const styledContent = <PopoverContent>{content}</PopoverContent>;
+    const styledContent = (
+      <PopoverContent {...contentProps}>{content}</PopoverContent>
+    );
 
     const trigger = React.cloneElement(children, {
       onClick: this.toggle
@@ -126,6 +129,11 @@ Popover.propTypes = {
    * Content to display within the Popover
    */
   content: PropTypes.node.isRequired,
+
+  /**
+   * Props to be passed to the PopoverContent component
+   */
+  contentProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 
   /**
    * The trigger which will open the popover when it is clicked. By default,
@@ -178,6 +186,7 @@ Popover.propTypes = {
 };
 
 Popover.defaultProps = {
+  contentProps: {},
   preferPlace: 'below',
   place: 'column',
   onOpen: () => null,

--- a/src/Popover/PopoverContent.js
+++ b/src/Popover/PopoverContent.js
@@ -7,7 +7,10 @@ const PopoverContent = styled(Card)`
   box-shadow: ${props => props.theme.shadows.elevation2};
   min-height: 40px;
   min-width: 160px;
-  overflow: hidden;
 `;
+
+PopoverContent.defaultProps = {
+  overflow: 'hidden'
+};
 
 export default PopoverContent;

--- a/src/Popover/__tests__/Popover.test.js
+++ b/src/Popover/__tests__/Popover.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import mountWithTheme from '../../../utils/mountWithTheme';
+import Card from '../../Card';
 import Popover from '../Popover';
 
 const mountNode = document.createElement('div');
@@ -41,6 +42,28 @@ describe('<Popover />', () => {
 
     expect(popover).toHaveProp({
       foo: 'bar'
+    });
+  });
+
+  describe('content', () => {
+    const renderPopoverContent = props => {
+      const popover = renderPopover(props);
+      const body = popover.prop('body');
+      return mount(body).find(Card);
+    };
+
+    it('defaults to overflow: hidden', () => {
+      const content = renderPopoverContent();
+
+      expect(content).toHaveProp({ overflow: 'hidden' });
+    });
+
+    it('supports passing explicit overflow', () => {
+      const content = renderPopoverContent({
+        contentProps: { overflow: 'visible' }
+      });
+
+      expect(content).toHaveProp({ overflow: 'visible' });
     });
   });
 


### PR DESCRIPTION
This is needed so we can customize overflow, which was previously
hardcoded to hidden.
    
[#172137996]
