### PR TITLE
expose paletteColor as a prop for StyledAutoCompleteMultiValue

### DIFF
--- a/dist/AutoComplete/StyledAutoCompleteMultiValue.js
+++ b/dist/AutoComplete/StyledAutoCompleteMultiValue.js
@@ -19,6 +19,14 @@ var _Icon = _interopRequireDefault(require("../Icon"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -30,8 +38,9 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 var StyledAutoCompleteMultiValue = function StyledAutoCompleteMultiValue(_ref) {
   var data = _ref.data,
       label = _ref.data.label,
+      paletteColor = _ref.paletteColor,
       removeProps = _ref.removeProps;
-  var paletteColor = (0, _utils.colorForString)(label, Object.keys(_colors.palette));
+  var color = paletteColor === null ? (0, _utils.colorForString)(label, Object.keys(_colors.palette)) : paletteColor;
 
   var iconEnd = _react["default"].createElement(_Icon["default"], _extends({
     "aria-label": "remove",
@@ -44,7 +53,7 @@ var StyledAutoCompleteMultiValue = function StyledAutoCompleteMultiValue(_ref) {
 
   return _react["default"].createElement(_Badge["default"], _objectSpread({
     iconEnd: iconEnd,
-    paletteColor: paletteColor,
+    paletteColor: color,
     subtle: true,
     variant: 'pill'
   }, data), label);
@@ -58,7 +67,11 @@ StyledAutoCompleteMultiValue.propTypes = {
     onClick: _propTypes["default"].func.isRequired,
     onMouseDown: _propTypes["default"].func.isRequired,
     onTouchEnd: _propTypes["default"].func.isRequired
-  }).isRequired
+  }).isRequired,
+  paletteColor: _propTypes["default"].oneOf([''].concat(_toConsumableArray(Object.keys(_colors.palette))))
+};
+StyledAutoCompleteMultiValue.defaultProps = {
+  paletteColor: null
 };
 var _default = StyledAutoCompleteMultiValue;
 exports["default"] = _default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.90.2",
+  "version": "0.90.3",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/AutoComplete/StyledAutoCompleteMultiValue.js
+++ b/src/AutoComplete/StyledAutoCompleteMultiValue.js
@@ -10,9 +10,13 @@ import Icon from '../Icon';
 const StyledAutoCompleteMultiValue = ({
   data,
   data: { label },
+  paletteColor,
   removeProps
 }) => {
-  const paletteColor = colorForString(label, Object.keys(palette));
+  const color =
+    paletteColor === null
+      ? colorForString(label, Object.keys(palette))
+      : paletteColor;
 
   const iconEnd = (
     <Icon
@@ -28,7 +32,7 @@ const StyledAutoCompleteMultiValue = ({
     <Badge
       {...{
         iconEnd,
-        paletteColor,
+        paletteColor: color,
         subtle: true,
         variant: 'pill',
         ...data
@@ -47,7 +51,12 @@ StyledAutoCompleteMultiValue.propTypes = {
     onClick: PropTypes.func.isRequired,
     onMouseDown: PropTypes.func.isRequired,
     onTouchEnd: PropTypes.func.isRequired
-  }).isRequired
+  }).isRequired,
+  paletteColor: PropTypes.oneOf(['', ...Object.keys(palette)])
+};
+
+StyledAutoCompleteMultiValue.defaultProps = {
+  paletteColor: null
 };
 
 export default StyledAutoCompleteMultiValue;

--- a/stories/autoComplete.stories.js
+++ b/stories/autoComplete.stories.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 
+import { styledAutoCompleteComponents } from '../src/AutoComplete';
 import notes from './autoComplete.md';
 import { AutoComplete, Box, Heading } from '../src';
 import palette from '../src/theme/colors/palette';
@@ -47,6 +48,10 @@ const filterOptions = (options, inputValue: '') =>
   options.filter(option =>
     option.label.toLowerCase().includes(inputValue.toLowerCase())
   );
+
+const { MultiValue } = styledAutoCompleteComponents;
+
+const NeutralMultiValue = props => <MultiValue {...props} paletteColor="" />;
 
 class AutoCompleteExample extends React.Component {
   state = {
@@ -157,6 +162,16 @@ stories.add(
           variant: 'default'
         }))}
         variant={select('Variant', variantOptions, 'default')}
+      />
+
+      <AutoCompleteExample
+        id="auto-complete-6"
+        label="AutoComplete with custom neutral badges"
+        options={neutralOptions}
+        variant={select('Variant', variantOptions, 'default')}
+        components={{
+          MultiValue: NeutralMultiValue
+        }}
       />
     </Box>
   ),


### PR DESCRIPTION
This is so there can be an easier-to-configure default. At the moment, to change the color requires copy/pasting the entire component from arbor, with a 1 line change, or having to set the color separately in every option sent in, which is horrible because the data shouldn't have to worry about that.

[#172137985]