### PR TITLE
Allow inputs to have values that are numbers or booleans, in addition to strings

### DIFF
--- a/dist/Input/Input.js
+++ b/dist/Input/Input.js
@@ -53,14 +53,15 @@ var Input = _react["default"].forwardRef(function (_ref, ref) {
       onBlur = _ref.onBlur,
       onChange = _ref.onChange,
       validate = _ref.validate,
-      props = _objectWithoutProperties(_ref, ["caption", "label", "labelAside", "id", "onBlur", "onChange", "validate"]);
+      propValue = _ref.value,
+      props = _objectWithoutProperties(_ref, ["caption", "label", "labelAside", "id", "onBlur", "onChange", "validate", "value"]);
 
   var _useState = (0, _react.useState)(false),
       _useState2 = _slicedToArray(_useState, 2),
       touched = _useState2[0],
       setTouched = _useState2[1];
 
-  var _useState3 = (0, _react.useState)(props.value),
+  var _useState3 = (0, _react.useState)(propValue),
       _useState4 = _slicedToArray(_useState3, 2),
       value = _useState4[0],
       setValue = _useState4[1];
@@ -92,6 +93,7 @@ var Input = _react["default"].forwardRef(function (_ref, ref) {
     id: id,
     ref: ref
   }), {
+    value: propValue ? propValue.toString() : propValue,
     isInvalid: !!errorMessage,
     onBlur: handleBlur,
     onChange: handleChange
@@ -148,7 +150,7 @@ Input.propTypes = {
   /**
    * HTML Input value
    */
-  value: _propTypes["default"].string
+  value: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].number, _propTypes["default"].bool])
 };
 Input.defaultProps = {
   as: 'input',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.92.7",
+  "version": "0.92.8",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -6,11 +6,21 @@ import StyledInput from './StyledInput';
 
 const Input = React.forwardRef(
   (
-    { caption, label, labelAside, id, onBlur, onChange, validate, ...props },
+    {
+      caption,
+      label,
+      labelAside,
+      id,
+      onBlur,
+      onChange,
+      validate,
+      value: propValue,
+      ...props
+    },
     ref
   ) => {
     const [touched, setTouched] = useState(false);
-    const [value, setValue] = useState(props.value);
+    const [value, setValue] = useState(propValue);
 
     const errorMessage = touched && validate(value);
 
@@ -39,6 +49,7 @@ const Input = React.forwardRef(
       >
         <StyledInput
           {...{ ...props, id, ref }}
+          value={propValue ? propValue.toString() : propValue}
           isInvalid={!!errorMessage}
           onBlur={handleBlur}
           onChange={handleChange}
@@ -98,7 +109,11 @@ Input.propTypes = {
   /**
    * HTML Input value
    */
-  value: PropTypes.string
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool
+  ])
 };
 
 Input.defaultProps = {

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -87,6 +87,13 @@ storiesOf('Input', module).add(
         name="validation-input-with-caption"
         validate={validateIs42}
       />
+      <Input
+        label="Input with non-string value prop (should not throw a prop-type warning)"
+        id="input-with-non-string-value"
+        name="input-with-non-string-value"
+        value={42}
+        validate={validateIs42}
+      />
     </form>
   ),
   { notes: { markdown: notes } }


### PR DESCRIPTION
We store the value in state, so there's no need to require it to be a string always (we're already using non-strings to begin with) - it just needs to be converted to one to render into the DOM.