### PR TITLE
Fix invalid value for prop cx warning emitted by autocomplete

### DIFF
--- a/dist/AutoComplete/StyledAutoCompleteClearIndicator.js
+++ b/dist/AutoComplete/StyledAutoCompleteClearIndicator.js
@@ -27,7 +27,8 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 
 var StyledAutoCompleteClearIndicator = function StyledAutoCompleteClearIndicator(_ref) {
   var innerProps = _ref.innerProps,
-      props = _objectWithoutProperties(_ref, ["innerProps"]);
+      cx = _ref.cx,
+      props = _objectWithoutProperties(_ref, ["innerProps", "cx"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Icon["default"], _extends({
     "aria-label": "clear selection",
@@ -37,6 +38,7 @@ var StyledAutoCompleteClearIndicator = function StyledAutoCompleteClearIndicator
 };
 
 StyledAutoCompleteClearIndicator.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   innerProps: _propTypes["default"].object.isRequired // eslint-disable-line react/forbid-prop-types
 
 };

--- a/dist/AutoComplete/StyledAutoCompleteContainer.js
+++ b/dist/AutoComplete/StyledAutoCompleteContainer.js
@@ -26,9 +26,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteContainer = function StyledAutoCompleteContainer(_ref) {
-  var innerRef = _ref.innerRef,
+  var cx = _ref.cx,
+      innerRef = _ref.innerRef,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerRef", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerRef", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Box["default"], _extends({
     ref: innerRef
@@ -36,6 +37,7 @@ var StyledAutoCompleteContainer = function StyledAutoCompleteContainer(_ref) {
 };
 
 StyledAutoCompleteContainer.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerRef: _propTypes["default"].func.isRequired
 };

--- a/dist/AutoComplete/StyledAutoCompleteControl.js
+++ b/dist/AutoComplete/StyledAutoCompleteControl.js
@@ -32,13 +32,14 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 var StyledFlex = ( /*#__PURE__*/0, _styledBase["default"])(_Flex["default"], {
   target: "e1i4rshr0",
   label: "StyledFlex"
-})(_Input.inputStyles, ";" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFPK0IiLCJmaWxlIjoiLi4vLi4vc3JjL0F1dG9Db21wbGV0ZS9TdHlsZWRBdXRvQ29tcGxldGVDb250cm9sLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0JztcbmltcG9ydCBQcm9wVHlwZXMgZnJvbSAncHJvcC10eXBlcyc7XG5pbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCc7XG5cbmltcG9ydCBGbGV4IGZyb20gJy4uL0ZsZXgnO1xuaW1wb3J0IHsgaW5wdXRTdHlsZXMgfSBmcm9tICcuLi9JbnB1dCc7XG5cbmNvbnN0IFN0eWxlZEZsZXggPSBzdHlsZWQoRmxleClgXG4gICR7aW5wdXRTdHlsZXN9O1xuYDtcblxuY29uc3QgU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbCA9ICh7XG4gIGlubmVyUmVmLFxuICBpbm5lclByb3BzLFxuICBjaGlsZHJlbixcbiAgLi4ucHJvcHNcbn0pID0+IChcbiAgPFN0eWxlZEZsZXggcmVmPXtpbm5lclJlZn0gey4uLnsgLi4uaW5uZXJQcm9wcywgLi4ucHJvcHMgfX0+XG4gICAge2NoaWxkcmVufVxuICA8L1N0eWxlZEZsZXg+XG4pO1xuXG5TdHlsZWRBdXRvQ29tcGxldGVDb250cm9sLnByb3BUeXBlcyA9IHtcbiAgY2hpbGRyZW46IFByb3BUeXBlcy5vbmVPZlR5cGUoW1xuICAgIFByb3BUeXBlcy5ub2RlLFxuICAgIFByb3BUeXBlcy5hcnJheU9mKFByb3BUeXBlcy5ub2RlKVxuICBdKS5pc1JlcXVpcmVkLFxuICBpbm5lclByb3BzOiBQcm9wVHlwZXMub2JqZWN0LmlzUmVxdWlyZWQsIC8vIGVzbGludC1kaXNhYmxlLWxpbmUgcmVhY3QvZm9yYmlkLXByb3AtdHlwZXNcbiAgaW5uZXJSZWY6IFByb3BUeXBlcy5mdW5jLmlzUmVxdWlyZWRcbn07XG5cbmV4cG9ydCBkZWZhdWx0IFN0eWxlZEF1dG9Db21wbGV0ZUNvbnRyb2w7XG4iXX0= */"));
+})(_Input.inputStyles, ";" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFPK0IiLCJmaWxlIjoiLi4vLi4vc3JjL0F1dG9Db21wbGV0ZS9TdHlsZWRBdXRvQ29tcGxldGVDb250cm9sLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0JztcbmltcG9ydCBQcm9wVHlwZXMgZnJvbSAncHJvcC10eXBlcyc7XG5pbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCc7XG5cbmltcG9ydCBGbGV4IGZyb20gJy4uL0ZsZXgnO1xuaW1wb3J0IHsgaW5wdXRTdHlsZXMgfSBmcm9tICcuLi9JbnB1dCc7XG5cbmNvbnN0IFN0eWxlZEZsZXggPSBzdHlsZWQoRmxleClgXG4gICR7aW5wdXRTdHlsZXN9O1xuYDtcblxuY29uc3QgU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbCA9ICh7XG4gIGN4LFxuICBpbm5lclJlZixcbiAgaW5uZXJQcm9wcyxcbiAgY2hpbGRyZW4sXG4gIC4uLnByb3BzXG59KSA9PiAoXG4gIDxTdHlsZWRGbGV4IHJlZj17aW5uZXJSZWZ9IHsuLi57IC4uLmlubmVyUHJvcHMsIC4uLnByb3BzIH19PlxuICAgIHtjaGlsZHJlbn1cbiAgPC9TdHlsZWRGbGV4PlxuKTtcblxuU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbC5wcm9wVHlwZXMgPSB7XG4gIGN4OiBQcm9wVHlwZXMuZnVuYy5pc1JlcXVpcmVkLFxuICBjaGlsZHJlbjogUHJvcFR5cGVzLm9uZU9mVHlwZShbXG4gICAgUHJvcFR5cGVzLm5vZGUsXG4gICAgUHJvcFR5cGVzLmFycmF5T2YoUHJvcFR5cGVzLm5vZGUpXG4gIF0pLmlzUmVxdWlyZWQsXG4gIGlubmVyUHJvcHM6IFByb3BUeXBlcy5vYmplY3QuaXNSZXF1aXJlZCwgLy8gZXNsaW50LWRpc2FibGUtbGluZSByZWFjdC9mb3JiaWQtcHJvcC10eXBlc1xuICBpbm5lclJlZjogUHJvcFR5cGVzLmZ1bmMuaXNSZXF1aXJlZFxufTtcblxuZXhwb3J0IGRlZmF1bHQgU3R5bGVkQXV0b0NvbXBsZXRlQ29udHJvbDtcbiJdfQ== */"));
 
 var StyledAutoCompleteControl = function StyledAutoCompleteControl(_ref) {
-  var innerRef = _ref.innerRef,
+  var cx = _ref.cx,
+      innerRef = _ref.innerRef,
       innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerRef", "innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerRef", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(StyledFlex, _extends({
     ref: innerRef
@@ -46,6 +47,7 @@ var StyledAutoCompleteControl = function StyledAutoCompleteControl(_ref) {
 };
 
 StyledAutoCompleteControl.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object.isRequired,
   // eslint-disable-line react/forbid-prop-types

--- a/dist/AutoComplete/StyledAutoCompleteDropdownIndicator.js
+++ b/dist/AutoComplete/StyledAutoCompleteDropdownIndicator.js
@@ -26,9 +26,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteDropdownIndicator = function StyledAutoCompleteDropdownIndicator(_ref) {
-  var innerProps = _ref.innerProps,
+  var cx = _ref.cx,
+      innerProps = _ref.innerProps,
       hideDropdownIndicator = _ref.selectProps.hideDropdownIndicator,
-      props = _objectWithoutProperties(_ref, ["innerProps", "selectProps"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerProps", "selectProps"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Icon["default"], _extends({
     display: hideDropdownIndicator ? 'none' : 'block',
@@ -38,6 +39,7 @@ var StyledAutoCompleteDropdownIndicator = function StyledAutoCompleteDropdownInd
 };
 
 StyledAutoCompleteDropdownIndicator.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   innerProps: _propTypes["default"].object,
   // eslint-disable-line react/forbid-prop-types
   selectProps: _propTypes["default"].shape({

--- a/dist/AutoComplete/StyledAutoCompleteIndicatorsContainer.js
+++ b/dist/AutoComplete/StyledAutoCompleteIndicatorsContainer.js
@@ -26,9 +26,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteIndicatorsContainer = function StyledAutoCompleteIndicatorsContainer(_ref) {
-  var innerProps = _ref.innerProps,
+  var cx = _ref.cx,
+      innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Grid["default"], _extends({
     alignItems: "center",
@@ -38,6 +39,7 @@ var StyledAutoCompleteIndicatorsContainer = function StyledAutoCompleteIndicator
 };
 
 StyledAutoCompleteIndicatorsContainer.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object // eslint-disable-line react/forbid-prop-types
 

--- a/dist/AutoComplete/StyledAutoCompleteInput.js
+++ b/dist/AutoComplete/StyledAutoCompleteInput.js
@@ -36,28 +36,45 @@ var StyledFlex = ( /*#__PURE__*/0, _styledBase["default"])(_Flex["default"], {
 }, ";font-size:", function (_ref2) {
   var theme = _ref2.theme;
   return theme.fontSizes.size4;
-}, ";&:focus{outline:none;}" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlSW5wdXQuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTStCIiwiZmlsZSI6Ii4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlSW5wdXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnO1xuaW1wb3J0IFByb3BUeXBlcyBmcm9tICdwcm9wLXR5cGVzJztcbmltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJztcblxuaW1wb3J0IEZsZXggZnJvbSAnLi4vRmxleCc7XG5cbmNvbnN0IFN0eWxlZEZsZXggPSBzdHlsZWQoRmxleClgXG4gIGZvbnQtZmFtaWx5OiAkeyh7IHRoZW1lIH0pID0+IHRoZW1lLmJyYW5kRm9udH07XG4gIGZvbnQtc2l6ZTogJHsoeyB0aGVtZSB9KSA9PiB0aGVtZS5mb250U2l6ZXMuc2l6ZTR9O1xuXG4gICY6Zm9jdXMge1xuICAgIG91dGxpbmU6IG5vbmU7XG4gIH1cbmA7XG5cbmNvbnN0IFN0eWxlZEF1dG9Db21wbGV0ZUlucHV0ID0gKHsgaW5uZXJSZWYsIGlubmVyUHJvcHMsIC4uLnByb3BzIH0pID0+IChcbiAgPFN0eWxlZEZsZXhcbiAgICBhcz1cImlucHV0XCJcbiAgICBib3JkZXI9XCJub25lXCJcbiAgICBmbGV4PVwiMVwiXG4gICAgcmVmPXtpbm5lclJlZn1cbiAgICB7Li4ueyAuLi5pbm5lclByb3BzLCAuLi5wcm9wcyB9fVxuICAvPlxuKTtcblxuU3R5bGVkQXV0b0NvbXBsZXRlSW5wdXQucHJvcFR5cGVzID0ge1xuICBpbm5lclByb3BzOiBQcm9wVHlwZXMub2JqZWN0LCAvLyBlc2xpbnQtZGlzYWJsZS1saW5lIHJlYWN0L2ZvcmJpZC1wcm9wLXR5cGVzXG4gIGlubmVyUmVmOiBQcm9wVHlwZXMuZnVuYy5pc1JlcXVpcmVkXG59O1xuXG5TdHlsZWRBdXRvQ29tcGxldGVJbnB1dC5kZWZhdWx0UHJvcHMgPSB7XG4gIGlubmVyUHJvcHM6IHt9XG59O1xuXG5leHBvcnQgZGVmYXVsdCBTdHlsZWRBdXRvQ29tcGxldGVJbnB1dDtcbiJdfQ== */"));
+}, ";&:focus{outline:none;}" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlSW5wdXQuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTStCIiwiZmlsZSI6Ii4uLy4uL3NyYy9BdXRvQ29tcGxldGUvU3R5bGVkQXV0b0NvbXBsZXRlSW5wdXQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnO1xuaW1wb3J0IFByb3BUeXBlcyBmcm9tICdwcm9wLXR5cGVzJztcbmltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJztcblxuaW1wb3J0IEZsZXggZnJvbSAnLi4vRmxleCc7XG5cbmNvbnN0IFN0eWxlZEZsZXggPSBzdHlsZWQoRmxleClgXG4gIGZvbnQtZmFtaWx5OiAkeyh7IHRoZW1lIH0pID0+IHRoZW1lLmJyYW5kRm9udH07XG4gIGZvbnQtc2l6ZTogJHsoeyB0aGVtZSB9KSA9PiB0aGVtZS5mb250U2l6ZXMuc2l6ZTR9O1xuXG4gICY6Zm9jdXMge1xuICAgIG91dGxpbmU6IG5vbmU7XG4gIH1cbmA7XG5cbmNvbnN0IFN0eWxlZEF1dG9Db21wbGV0ZUlucHV0ID0gKHtcbiAgY3gsXG4gIGdldFN0eWxlcyxcbiAgaW5uZXJQcm9wcyxcbiAgaW5uZXJSZWYsXG4gIGlzRGlzYWJsZWQsXG4gIGlzSGlkZGVuLFxuICBzZWxlY3RQcm9wcyxcbiAgdGhlbWUsXG4gIC4uLnByb3BzXG59KSA9PiB7XG4gIHJldHVybiAoXG4gICAgPFN0eWxlZEZsZXhcbiAgICAgIGFzPVwiaW5wdXRcIlxuICAgICAgYm9yZGVyPVwibm9uZVwiXG4gICAgICBmbGV4PVwiMVwiXG4gICAgICBkaXNhYmxlZD17aXNEaXNhYmxlZH1cbiAgICAgIHJlZj17aW5uZXJSZWZ9XG4gICAgICB7Li4ueyAuLi5pbm5lclByb3BzLCAuLi5wcm9wcyB9fVxuICAgIC8+XG4gICk7XG59O1xuXG5TdHlsZWRBdXRvQ29tcGxldGVJbnB1dC5wcm9wVHlwZXMgPSB7XG4gIGN4OiBQcm9wVHlwZXMuZnVuYy5pc1JlcXVpcmVkLFxuICBnZXRTdHlsZXM6IFByb3BUeXBlcy5mdW5jLmlzUmVxdWlyZWQsXG4gIGlubmVyUHJvcHM6IFByb3BUeXBlcy5vYmplY3QsIC8vIGVzbGludC1kaXNhYmxlLWxpbmUgcmVhY3QvZm9yYmlkLXByb3AtdHlwZXNcbiAgaW5uZXJSZWY6IFByb3BUeXBlcy5mdW5jLmlzUmVxdWlyZWQsXG4gIGlzRGlzYWJsZWQ6IFByb3BUeXBlcy5ib29sLFxuICBpc0hpZGRlbjogUHJvcFR5cGVzLmJvb2wsXG4gIHNlbGVjdFByb3BzOiBQcm9wVHlwZXMub2JqZWN0LmlzUmVxdWlyZWQsIC8vIGVzbGludC1kaXNhYmxlLWxpbmUgcmVhY3QvZm9yYmlkLXByb3AtdHlwZXNcbiAgdGhlbWU6IFByb3BUeXBlcy5vYmplY3QuaXNSZXF1aXJlZCAvLyBlc2xpbnQtZGlzYWJsZS1saW5lIHJlYWN0L2ZvcmJpZC1wcm9wLXR5cGVzXG59O1xuXG5TdHlsZWRBdXRvQ29tcGxldGVJbnB1dC5kZWZhdWx0UHJvcHMgPSB7XG4gIGlubmVyUHJvcHM6IHt9LFxuICBpc0hpZGRlbjogdW5kZWZpbmVkLFxuICBpc0Rpc2FibGVkOiB1bmRlZmluZWRcbn07XG5cbmV4cG9ydCBkZWZhdWx0IFN0eWxlZEF1dG9Db21wbGV0ZUlucHV0O1xuIl19 */"));
 
 var StyledAutoCompleteInput = function StyledAutoCompleteInput(_ref3) {
-  var innerRef = _ref3.innerRef,
+  var cx = _ref3.cx,
+      getStyles = _ref3.getStyles,
       innerProps = _ref3.innerProps,
-      props = _objectWithoutProperties(_ref3, ["innerRef", "innerProps"]);
+      innerRef = _ref3.innerRef,
+      isDisabled = _ref3.isDisabled,
+      isHidden = _ref3.isHidden,
+      selectProps = _ref3.selectProps,
+      theme = _ref3.theme,
+      props = _objectWithoutProperties(_ref3, ["cx", "getStyles", "innerProps", "innerRef", "isDisabled", "isHidden", "selectProps", "theme"]);
 
   return /*#__PURE__*/_react["default"].createElement(StyledFlex, _extends({
     as: "input",
     border: "none",
     flex: "1",
+    disabled: isDisabled,
     ref: innerRef
   }, _objectSpread(_objectSpread({}, innerProps), props)));
 };
 
 StyledAutoCompleteInput.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
+  getStyles: _propTypes["default"].func.isRequired,
   innerProps: _propTypes["default"].object,
   // eslint-disable-line react/forbid-prop-types
-  innerRef: _propTypes["default"].func.isRequired
+  innerRef: _propTypes["default"].func.isRequired,
+  isDisabled: _propTypes["default"].bool,
+  isHidden: _propTypes["default"].bool,
+  selectProps: _propTypes["default"].object.isRequired,
+  // eslint-disable-line react/forbid-prop-types
+  theme: _propTypes["default"].object.isRequired // eslint-disable-line react/forbid-prop-types
+
 };
 StyledAutoCompleteInput.defaultProps = {
-  innerProps: {}
+  innerProps: {},
+  isHidden: undefined,
+  isDisabled: undefined
 };
 var _default = StyledAutoCompleteInput;
 exports["default"] = _default;

--- a/dist/AutoComplete/StyledAutoCompleteMenu.js
+++ b/dist/AutoComplete/StyledAutoCompleteMenu.js
@@ -28,9 +28,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteMenu = function StyledAutoCompleteMenu(_ref) {
-  var innerProps = _ref.innerProps,
+  var cx = _ref.cx,
+      innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Card["default"], _extends({
     mt: "smaller",
@@ -41,6 +42,7 @@ var StyledAutoCompleteMenu = function StyledAutoCompleteMenu(_ref) {
 };
 
 StyledAutoCompleteMenu.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object.isRequired // eslint-disable-line react/forbid-prop-types
 

--- a/dist/AutoComplete/StyledAutoCompleteMenuList.js
+++ b/dist/AutoComplete/StyledAutoCompleteMenuList.js
@@ -28,10 +28,11 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteMenuList = function StyledAutoCompleteMenuList(_ref) {
-  var innerRef = _ref.innerRef,
+  var cx = _ref.cx,
+      innerRef = _ref.innerRef,
       innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerRef", "innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerRef", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Box["default"], _extends({
     as: "ul",
@@ -41,6 +42,7 @@ var StyledAutoCompleteMenuList = function StyledAutoCompleteMenuList(_ref) {
 };
 
 StyledAutoCompleteMenuList.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object,
   // eslint-disable-line react/forbid-prop-types

--- a/dist/AutoComplete/StyledAutoCompleteNoOptionsMessage.js
+++ b/dist/AutoComplete/StyledAutoCompleteNoOptionsMessage.js
@@ -26,10 +26,11 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteNoOption = function StyledAutoCompleteNoOption(_ref) {
-  var innerRef = _ref.innerRef,
+  var cx = _ref.cx,
+      innerRef = _ref.innerRef,
       innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerRef", "innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerRef", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Text["default"], _extends({
     p: "small",
@@ -39,6 +40,7 @@ var StyledAutoCompleteNoOption = function StyledAutoCompleteNoOption(_ref) {
 };
 
 StyledAutoCompleteNoOption.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object.isRequired,
   // eslint-disable-line react/forbid-prop-types

--- a/dist/AutoComplete/StyledAutoCompleteOption.js
+++ b/dist/AutoComplete/StyledAutoCompleteOption.js
@@ -28,9 +28,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteOption = function StyledAutoCompleteOption(_ref) {
-  var innerProps = _ref.innerProps,
+  var cx = _ref.cx,
+      innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_MenuItem["default"], _extends({
     as: "li"
@@ -38,6 +39,7 @@ var StyledAutoCompleteOption = function StyledAutoCompleteOption(_ref) {
 };
 
 StyledAutoCompleteOption.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object.isRequired // eslint-disable-line react/forbid-prop-types
 

--- a/dist/AutoComplete/StyledAutoCompletePlaceholder.js
+++ b/dist/AutoComplete/StyledAutoCompletePlaceholder.js
@@ -20,8 +20,9 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompletePlaceholder = function StyledAutoCompletePlaceholder(_ref) {
-  var children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["children"]);
+  var cx = _ref.cx,
+      children = _ref.children,
+      props = _objectWithoutProperties(_ref, ["cx", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Flex["default"], _extends({
     alignSelf: "center",
@@ -31,6 +32,7 @@ var StyledAutoCompletePlaceholder = function StyledAutoCompletePlaceholder(_ref)
 };
 
 StyledAutoCompletePlaceholder.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired
 };
 var _default = StyledAutoCompletePlaceholder;

--- a/dist/AutoComplete/StyledAutoCompleteValueContainer.js
+++ b/dist/AutoComplete/StyledAutoCompleteValueContainer.js
@@ -26,9 +26,10 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var StyledAutoCompleteValueContainer = function StyledAutoCompleteValueContainer(_ref) {
-  var innerProps = _ref.innerProps,
+  var cx = _ref.cx,
+      innerProps = _ref.innerProps,
       children = _ref.children,
-      props = _objectWithoutProperties(_ref, ["innerProps", "children"]);
+      props = _objectWithoutProperties(_ref, ["cx", "innerProps", "children"]);
 
   return /*#__PURE__*/_react["default"].createElement(_Flex["default"], _extends({
     flex: "1",
@@ -38,6 +39,7 @@ var StyledAutoCompleteValueContainer = function StyledAutoCompleteValueContainer
 };
 
 StyledAutoCompleteValueContainer.propTypes = {
+  cx: _propTypes["default"].func.isRequired,
   children: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].arrayOf(_propTypes["default"].node)]).isRequired,
   innerProps: _propTypes["default"].object // eslint-disable-line react/forbid-prop-types
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.92.9",
+  "version": "0.92.10",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/AutoComplete/StyledAutoCompleteClearIndicator.js
+++ b/src/AutoComplete/StyledAutoCompleteClearIndicator.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Icon from '../Icon';
 
-const StyledAutoCompleteClearIndicator = ({ innerProps, ...props }) => (
+const StyledAutoCompleteClearIndicator = ({ innerProps, cx, ...props }) => (
   <Icon
     aria-label="clear selection"
     fontSize="size4"
@@ -13,6 +13,7 @@ const StyledAutoCompleteClearIndicator = ({ innerProps, ...props }) => (
 );
 
 StyledAutoCompleteClearIndicator.propTypes = {
+  cx: PropTypes.func.isRequired,
   innerProps: PropTypes.object.isRequired // eslint-disable-line react/forbid-prop-types
 };
 

--- a/src/AutoComplete/StyledAutoCompleteContainer.js
+++ b/src/AutoComplete/StyledAutoCompleteContainer.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 import Box from '../Box';
 
-const StyledAutoCompleteContainer = ({ innerRef, children, ...props }) => (
+const StyledAutoCompleteContainer = ({ cx, innerRef, children, ...props }) => (
   <Box ref={innerRef} {...{ ...props }}>
     {children}
   </Box>
 );
 
 StyledAutoCompleteContainer.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteControl.js
+++ b/src/AutoComplete/StyledAutoCompleteControl.js
@@ -10,6 +10,7 @@ const StyledFlex = styled(Flex)`
 `;
 
 const StyledAutoCompleteControl = ({
+  cx,
   innerRef,
   innerProps,
   children,
@@ -21,6 +22,7 @@ const StyledAutoCompleteControl = ({
 );
 
 StyledAutoCompleteControl.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteDropdownIndicator.js
+++ b/src/AutoComplete/StyledAutoCompleteDropdownIndicator.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Icon from '../Icon';
 
 const StyledAutoCompleteDropdownIndicator = ({
+  cx,
   innerProps,
   selectProps: { hideDropdownIndicator },
   ...props
@@ -17,6 +18,7 @@ const StyledAutoCompleteDropdownIndicator = ({
 );
 
 StyledAutoCompleteDropdownIndicator.propTypes = {
+  cx: PropTypes.func.isRequired,
   innerProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   selectProps: PropTypes.shape({
     hideDropdownIndicator: PropTypes.bool

--- a/src/AutoComplete/StyledAutoCompleteIndicatorsContainer.js
+++ b/src/AutoComplete/StyledAutoCompleteIndicatorsContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Grid from '../Grid';
 
 const StyledAutoCompleteIndicatorsContainer = ({
+  cx,
   innerProps,
   children,
   ...props
@@ -19,6 +20,7 @@ const StyledAutoCompleteIndicatorsContainer = ({
 );
 
 StyledAutoCompleteIndicatorsContainer.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteInput.js
+++ b/src/AutoComplete/StyledAutoCompleteInput.js
@@ -13,23 +13,44 @@ const StyledFlex = styled(Flex)`
   }
 `;
 
-const StyledAutoCompleteInput = ({ innerRef, innerProps, ...props }) => (
-  <StyledFlex
-    as="input"
-    border="none"
-    flex="1"
-    ref={innerRef}
-    {...{ ...innerProps, ...props }}
-  />
-);
+const StyledAutoCompleteInput = ({
+  cx,
+  getStyles,
+  innerProps,
+  innerRef,
+  isDisabled,
+  isHidden,
+  selectProps,
+  theme,
+  ...props
+}) => {
+  return (
+    <StyledFlex
+      as="input"
+      border="none"
+      flex="1"
+      disabled={isDisabled}
+      ref={innerRef}
+      {...{ ...innerProps, ...props }}
+    />
+  );
+};
 
 StyledAutoCompleteInput.propTypes = {
+  cx: PropTypes.func.isRequired,
+  getStyles: PropTypes.func.isRequired,
   innerProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  innerRef: PropTypes.func.isRequired
+  innerRef: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+  isHidden: PropTypes.bool,
+  selectProps: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  theme: PropTypes.object.isRequired // eslint-disable-line react/forbid-prop-types
 };
 
 StyledAutoCompleteInput.defaultProps = {
-  innerProps: {}
+  innerProps: {},
+  isHidden: undefined,
+  isDisabled: undefined
 };
 
 export default StyledAutoCompleteInput;

--- a/src/AutoComplete/StyledAutoCompleteMenu.js
+++ b/src/AutoComplete/StyledAutoCompleteMenu.js
@@ -4,7 +4,7 @@ import { withTheme } from 'emotion-theming';
 
 import Card from '../Card';
 
-const StyledAutoCompleteMenu = ({ innerProps, children, ...props }) => (
+const StyledAutoCompleteMenu = ({ cx, innerProps, children, ...props }) => (
   <Card
     mt="smaller"
     position="absolute"
@@ -17,6 +17,7 @@ const StyledAutoCompleteMenu = ({ innerProps, children, ...props }) => (
 );
 
 StyledAutoCompleteMenu.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteMenuList.js
+++ b/src/AutoComplete/StyledAutoCompleteMenuList.js
@@ -5,6 +5,7 @@ import { withTheme } from 'emotion-theming';
 import Box from '../Box';
 
 const StyledAutoCompleteMenuList = ({
+  cx,
   innerRef,
   innerProps,
   children,
@@ -16,6 +17,7 @@ const StyledAutoCompleteMenuList = ({
 );
 
 StyledAutoCompleteMenuList.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteNoOptionsMessage.js
+++ b/src/AutoComplete/StyledAutoCompleteNoOptionsMessage.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Text from '../Text';
 
 const StyledAutoCompleteNoOption = ({
+  cx,
   innerRef,
   innerProps,
   children,
@@ -20,6 +21,7 @@ const StyledAutoCompleteNoOption = ({
 );
 
 StyledAutoCompleteNoOption.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteOption.js
+++ b/src/AutoComplete/StyledAutoCompleteOption.js
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types';
 import MenuItem from '../MenuItem';
 import Text from '../Text';
 
-const StyledAutoCompleteOption = ({ innerProps, children, ...props }) => (
+const StyledAutoCompleteOption = ({ cx, innerProps, children, ...props }) => (
   <MenuItem as="li" {...{ ...innerProps, ...props }}>
     <Text>{children}</Text>
   </MenuItem>
 );
 
 StyledAutoCompleteOption.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompletePlaceholder.js
+++ b/src/AutoComplete/StyledAutoCompletePlaceholder.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Flex from '../Flex';
 
-const StyledAutoCompletePlaceholder = ({ children, ...props }) => (
+const StyledAutoCompletePlaceholder = ({ cx, children, ...props }) => (
   <Flex
     alignSelf="center"
     color="text.placeholder"
@@ -15,6 +15,7 @@ const StyledAutoCompletePlaceholder = ({ children, ...props }) => (
 );
 
 StyledAutoCompletePlaceholder.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/StyledAutoCompleteValueContainer.js
+++ b/src/AutoComplete/StyledAutoCompleteValueContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Flex from '../Flex';
 
 const StyledAutoCompleteValueContainer = ({
+  cx,
   innerProps,
   children,
   ...props
@@ -19,6 +20,7 @@ const StyledAutoCompleteValueContainer = ({
 );
 
 StyledAutoCompleteValueContainer.propTypes = {
+  cx: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)

--- a/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
+++ b/src/AutoComplete/__tests__/__snapshots__/AutoComplete.test.js.snap
@@ -207,18 +207,15 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -229,7 +226,7 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-2-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -242,7 +239,6 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -252,7 +248,6 @@ exports[`<AutoComplete /> Variants properly renders a async auto complete 1`] = 
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="block"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
@@ -476,18 +471,15 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -498,7 +490,7 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-3-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -511,7 +503,6 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -521,7 +512,6 @@ exports[`<AutoComplete /> Variants properly renders a asyncCreatable auto comple
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="block"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
@@ -745,18 +735,15 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -767,7 +754,7 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-4-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -780,7 +767,6 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -790,7 +776,6 @@ exports[`<AutoComplete /> Variants properly renders a creatable auto complete 1`
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="block"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
@@ -1014,18 +999,15 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -1036,7 +1018,7 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-5-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1049,7 +1031,6 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -1059,7 +1040,6 @@ exports[`<AutoComplete /> Variants properly renders a default auto complete 1`] 
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="block"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
@@ -1283,18 +1263,15 @@ exports[`<AutoComplete /> hideDropdownIndicator false renders the auto complete 
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -1305,7 +1282,7 @@ exports[`<AutoComplete /> hideDropdownIndicator false renders the auto complete 
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-6-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1318,7 +1295,6 @@ exports[`<AutoComplete /> hideDropdownIndicator false renders the auto complete 
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -1328,7 +1304,6 @@ exports[`<AutoComplete /> hideDropdownIndicator false renders the auto complete 
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="block"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
@@ -1552,18 +1527,15 @@ exports[`<AutoComplete /> hideDropdownIndicator true renders the auto complete w
   >
     <div
       className="emotion-17 emotion-18"
-      cx={[Function]}
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
       <div
         className="emotion-10 emotion-3"
-        cx={[Function]}
       >
         <div
           className="emotion-6 emotion-3"
           color="text.placeholder"
-          cx={[Function]}
         >
           Select...
         </div>
@@ -1574,7 +1546,7 @@ exports[`<AutoComplete /> hideDropdownIndicator true renders the auto complete w
           autoComplete="off"
           autoCorrect="off"
           className="emotion-8 emotion-9"
-          cx={[Function]}
+          disabled={false}
           id="react-select-7-input"
           onBlur={[Function]}
           onChange={[Function]}
@@ -1587,7 +1559,6 @@ exports[`<AutoComplete /> hideDropdownIndicator true renders the auto complete w
       </div>
       <div
         className="emotion-15 emotion-16"
-        cx={[Function]}
         display="grid"
       >
         <span
@@ -1597,7 +1568,6 @@ exports[`<AutoComplete /> hideDropdownIndicator true renders the auto complete w
           aria-hidden="true"
           aria-label="show options"
           className="ar ar-chevron emotion-13 emotion-14"
-          cx={[Function]}
           display="none"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}

--- a/stories/autoComplete.stories.js
+++ b/stories/autoComplete.stories.js
@@ -96,6 +96,7 @@ class AutoCompleteExample extends React.Component {
             }`,
             hideDropdownIndicator: boolean('hideDropdownIndicator', false),
             isMulti: boolean('isMulti', true),
+            isDisabled: boolean('isDisabled', false),
             onChange: this.handleChange,
             value: selectedOption,
             ...this.additionalProps,


### PR DESCRIPTION
cx is a valid html attribute for svg element.
react-select also has a cx prop which is a function.

Spreading the props of react-select on any dom elements causes the warning.
So we need to extract the cx prop first within all our customized components.