### PR TITLE
Switch to headless tippyjs and add framer-motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "@tippyjs/react": "^4.1.0",
     "babel-plugin-emotion": "^10.0.33",
     "emotion-theming": "^10.0.27",
+    "framer-motion": "^2.3.0",
     "lodash": "^4.17.11",
     "moment": "^2.25.3",
     "polished": "^3.6.3",

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -1,75 +1,104 @@
 /** @jsx jsx */
 import { useState } from 'react'; /* eslint-disable-line no-unused-vars */
-import { jsx } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 import PropTypes from 'prop-types';
-import Tippy from '@tippyjs/react';
-import 'tippy.js/dist/tippy.css';
-import { animateFill, sticky } from 'tippy.js';
-import styled from '@emotion/styled';
+import Tippy from '@tippyjs/react/headless';
+import { sticky } from 'tippy.js';
+import { motion } from 'framer-motion';
 
-const StyledTippy = styled(Tippy)`
-  background: none;
-  padding: 0;
+import Box from '../Box';
+import Card from '../Card';
+import Grid from '../Grid';
+import Heading from '../Heading';
+import Text from '../Text';
 
-  &[data-placement^='top'] > .tippy-arrow::before {
-    border-top-color: ${(props) => props.theme.colors.monochrome.grey90};
-  }
-
-  &[data-placement^='bottom'] > .tippy-arrow::before {
-    border-bottom-color: ${(props) => props.theme.colors.monochrome.grey90};
-  }
-
-  &[data-placement^='left'] > .tippy-arrow::before {
-    border-left-color: ${(props) => props.theme.colors.monochrome.grey90};
-  }
-
-  &[data-placement^='right'] > .tippy-arrow::before {
-    border-right-color: ${(props) => props.theme.colors.monochrome.grey90};
-  }
-
-  .tippy-content {
-    background: ${(props) => props.theme.colors.monochrome.grey90};
-    border-radius: ${(props) => props.theme.space.small};
-    color: ${(props) => props.theme.colors.monochrome.white};
-    font-size: ${(props) => props.theme.fontSizes.size4};
-    padding: ${(props) => props.theme.space.smaller};
-    font-family: ${(props) => props.theme.brandFont};
-    line-height: ${(props) => props.theme.space.small};
-  }
-`;
-
-const Tooltip = ({ content, children, render, ...props }) => {
+const Tooltip = ({ title, content, children, render, ...props }) => {
   const [mounted, setMounted] = useState(false);
 
   const lazyPlugin = {
     fn: () => ({
-      onShow: () => setMounted(true),
-      onHidden: () => setMounted(false)
+      onMount: () => setMounted(true),
+      onHide: () => setMounted(false)
     })
   };
+  const springConfig = {
+    type: 'spring',
+    damping: 24,
+    stiffness: 480,
+    restSpeed: 0.1,
+    restDelta: 0.6
+  };
 
-  const renderProps = {};
+  const variants = {
+    visible: { opacity: 1, scale: 1 },
+    hidden: { opacity: 0, scale: 0.5 }
+  };
 
-  if (render) {
-    renderProps.render = (...args) => (mounted ? render(...args) : '');
-  } else {
-    renderProps.content = mounted ? content : '';
-  }
+  const renderTooltip = (attrs) => (
+    <Box
+      as={motion.div}
+      initial="hidden"
+      variants={variants}
+      animate={mounted ? 'visible' : 'hidden'}
+      transition={springConfig}
+      {...attrs}
+    >
+      <Card
+        bg="monochrome.grey90"
+        borderRadius="small"
+        boxShadow="elevation1"
+        color="monochrome.white"
+        gridGap="smallest"
+        fontSize="size3"
+        maxWidth="200px"
+        p="smaller"
+        css={css`
+          word-break: break-word;
+        `}
+        {...props}
+      >
+        {title && (
+          <Heading.h3
+            mb="0"
+            fontSize="inherit"
+            color="inherit"
+            textAlign="inherit"
+          >
+            {title}
+          </Heading.h3>
+        )}
+        {content && (
+          <Text
+            as={Grid}
+            fontSize="inherit"
+            color="inherit"
+            textAlign="inherit"
+          >
+            {content}
+          </Text>
+        )}
+      </Card>
+    </Box>
+  );
 
   return (
-    <StyledTippy
-      {...{
-        arrow: true,
-        duration: 300,
-        animation: 'fade',
-        inertia: true,
-        plugins: [animateFill, sticky, lazyPlugin],
-        ...props,
-        ...renderProps
+    <Tippy
+      render={(attrs) => (mounted ? renderTooltip(attrs) : '')}
+      offset={[0, 4]}
+      plugins={[sticky, lazyPlugin]}
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'preventOverflow',
+            options: {
+              padding: 4
+            }
+          }
+        ]
       }}
     >
       {children}
-    </StyledTippy>
+    </Tippy>
   );
 };
 
@@ -86,6 +115,11 @@ Tooltip.propTypes = {
   content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
+   * Title to display above the tooltip content
+   * */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+
+  /**
    * Render function for rendering tippy element from scratch
    */
   render: PropTypes.func
@@ -93,6 +127,7 @@ Tooltip.propTypes = {
 
 Tooltip.defaultProps = {
   content: null,
+  title: null,
   render: null
 };
 

--- a/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -1,54 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tooltip /> properly renders a tooltip 1`] = `
-.emotion-0 {
-  background: none;
-  padding: 0;
-}
-
-.emotion-0[data-placement^='top'] > .tippy-arrow::before {
-  border-top-color: #25272D;
-}
-
-.emotion-0[data-placement^='bottom'] > .tippy-arrow::before {
-  border-bottom-color: #25272D;
-}
-
-.emotion-0[data-placement^='left'] > .tippy-arrow::before {
-  border-left-color: #25272D;
-}
-
-.emotion-0[data-placement^='right'] > .tippy-arrow::before {
-  border-right-color: #25272D;
-}
-
-.emotion-0 .tippy-content {
-  background: #25272D;
-  border-radius: 0.75rem;
-  color: #FFFFFF;
-  font-size: 0.875rem;
-  padding: 0.5rem;
-  font-family: Motiva Sans;
-  line-height: 0.75rem;
-}
-
 <Tooltip
   content="Hello World"
   render={null}
+  title={null}
 >
-  <StyledTippy
-    animation="fade"
-    arrow={true}
-    content=""
-    duration={300}
-    inertia={true}
+  <ForwardRef(TippyWrapper)
+    offset={
+      Array [
+        0,
+        4,
+      ]
+    }
     plugins={
       Array [
-        Object {
-          "defaultValue": false,
-          "fn": [Function],
-          "name": "animateFill",
-        },
         Object {
           "defaultValue": false,
           "fn": [Function],
@@ -59,21 +25,29 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
         },
       ]
     }
+    popperOptions={
+      Object {
+        "modifiers": Array [
+          Object {
+            "name": "preventOverflow",
+            "options": Object {
+              "padding": 4,
+            },
+          },
+        ],
+      }
+    }
+    render={[Function]}
   >
-    <ForwardRef(TippyWrapper)
-      animation="fade"
-      arrow={true}
-      className="emotion-0 emotion-1"
-      content=""
-      duration={300}
-      inertia={true}
+    <Tippy
+      offset={
+        Array [
+          0,
+          4,
+        ]
+      }
       plugins={
         Array [
-          Object {
-            "defaultValue": false,
-            "fn": [Function],
-            "name": "animateFill",
-          },
           Object {
             "defaultValue": false,
             "fn": [Function],
@@ -84,44 +58,35 @@ exports[`<Tooltip /> properly renders a tooltip 1`] = `
           },
         ]
       }
-    >
-      <Tippy
-        animation="fade"
-        arrow={true}
-        className="emotion-0 emotion-1"
-        content=""
-        duration={300}
-        inertia={true}
-        plugins={
-          Array [
+      popperOptions={
+        Object {
+          "modifiers": Array [
             Object {
-              "defaultValue": false,
-              "fn": [Function],
-              "name": "animateFill",
+              "name": "preventOverflow",
+              "options": Object {
+                "padding": 4,
+              },
             },
-            Object {
-              "defaultValue": false,
-              "fn": [Function],
-              "name": "sticky",
-            },
-            Object {
-              "fn": [Function],
-            },
-          ]
+          ],
         }
-      >
-        <p>
-          I have a tooltip
-        </p>
-        <Portal
-          containerInfo={
-            <div>
-              
-            </div>
-          }
-        />
-      </Tippy>
-    </ForwardRef(TippyWrapper)>
-  </StyledTippy>
+      }
+      render={[Function]}
+    >
+      <p>
+        I have a tooltip
+      </p>
+      <Portal
+        containerInfo={
+          <div
+            data-tippy-root=""
+            id="tippy-1"
+            style="pointer-events: none; z-index: 9999;"
+          >
+            
+          </div>
+        }
+      />
+    </Tippy>
+  </ForwardRef(TippyWrapper)>
 </Tooltip>
 `;

--- a/stories/tooltip.stories.js
+++ b/stories/tooltip.stories.js
@@ -9,26 +9,20 @@ import {
   Grid,
   Icon,
   Link,
-  Paragraph,
-  Text,
+  Heading,
   Tooltip
 } from '../src';
 
 const stories = storiesOf('Tooltips', module);
 
-const buttonIcon = <Icon name="download" />;
+const buttonIcon = <Icon name="download-fas" />;
 
 const FancyTooltipContent = () => (
-  <Box textAlign="left" maxWidth="200px">
-    <Grid gridGap="smallest" gridTemplateColumns="0fr 1fr" mb="smallest">
-      <Icon color="intent.brand.light" name="cr-logo" />
-      <Text color="inherit" fontWeight="bold">
-        Title of some content!
-      </Text>
-    </Grid>
-    <Paragraph variant="ui" color="inherit">
-      More detail to explain what the title actually means.
-    </Paragraph>
+  <Box fontSize="size9">
+    <Icon color="intent.brand.light" name="cr-logo" />
+    <Heading color="monochrome.white">
+      A tooltip&apos;s content and title props can accept custom components
+    </Heading>
   </Box>
 );
 
@@ -36,56 +30,63 @@ stories.add(
   'default',
   () => (
     <Grid
-      m="largest"
+      padding="large"
       gridGap="large"
-      gridTemplateColumns="repeat(3, 1fr)"
+      gridTemplateColumns="repeat(3,1fr)"
+      alignContent="start"
+      alignItems="center"
       justifyItems="center"
     >
-      <Box>
-        <Tooltip placement="bottom" content={<FancyTooltipContent />}>
-          <div>
-            <Button variant="primary">Button</Button>
-          </div>
-        </Tooltip>
-      </Box>
+      <Tooltip placement="bottom" content={<FancyTooltipContent />}>
+        <Button variant="primary">tooltip with custom content</Button>
+      </Tooltip>
 
-      <Box>
-        <Tooltip content="I'm a tooltip!">
-          <Button variant="primary" size="small">
-            Button
-          </Button>
-        </Tooltip>
-      </Box>
+      <Tooltip
+        title="A tooltip title"
+        content="Here's an example of a tooltip that has a title."
+      >
+        <Button variant="minimal" iconStart={<Icon name="thumbs-up-fas" />}>
+          tooltip with title
+        </Button>
+      </Tooltip>
 
-      <Box>
-        <Tooltip placement="right" content="Icon Button!">
-          <Button iconEnd={buttonIcon}>Icon Button</Button>
-        </Tooltip>
-      </Box>
+      <Tooltip
+        title="Other props"
+        content="The tooltip container accepts all Grid props. Title and content inherit fontSize, color, and textAlign."
+        fontSize="size7"
+        color="palette.purple.default"
+        padding="large"
+        justifyItems="center"
+        gridGap="small"
+        bg="monochrome.white"
+        borderRadius="larger"
+      >
+        <Button variant="minimal" iconStart={<Icon name="info-circle" />}>
+          other props
+        </Button>
+      </Tooltip>
 
-      <Box>
-        <Tooltip content="Eight action items have been accepted.">
-          <Link
-            href="#tooltip"
-            variant="muted"
-            onClick={(e) => e.preventDefault()}
-          >
-            8 Action Items
-          </Link>
-        </Tooltip>
-      </Box>
+      <Tooltip content="Download">
+        <Button variant="minimal" iconStart={buttonIcon} />
+      </Tooltip>
 
-      <Box>
-        <Tooltip placement="right" content="John Doe">
-          <Avatar name="John Doe" />
-        </Tooltip>
-      </Box>
+      <Tooltip content="Eight action items have been accepted.">
+        <Link
+          href="#tooltip"
+          variant="muted"
+          onClick={(e) => e.preventDefault()}
+        >
+          8 Action Items
+        </Link>
+      </Tooltip>
 
-      <Box>
-        <Tooltip placement="right" content="Download Icon!">
-          <Icon name="download" />
-        </Tooltip>
-      </Box>
+      <Tooltip content="John Doe">
+        <Avatar name="John Doe" />
+      </Tooltip>
+
+      <Tooltip placement="right" content="Info Icon!">
+        <Icon name="info-circle" />
+      </Tooltip>
     </Grid>
   ),
   { notes: { markdown: notes } }

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.2":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1342,6 +1342,22 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
+  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
+
+"@popmotion/popcorn@^0.4.2":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.4.tgz#a5f906fccdff84526e3fcb892712d7d8a98d6adc"
+  integrity sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    framesync "^4.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.7"
+    tslib "^1.10.0"
 
 "@popperjs/core@^2.4.4":
   version "2.4.4"
@@ -5815,6 +5831,29 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-2.3.0.tgz#700c3d6a554c86bfa6a2d96e25f25829667cd0b4"
+  integrity sha512-zX6V5vz3joMzacqV7UpiHKUtqLMmU/YsVM6KpeRCi65KjUiymUX5O2jkpR3cCdlr1DkJ1yWUjBWY7xyiO834VA==
+  dependencies:
+    "@popmotion/easing" "^1.0.2"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    popmotion "9.0.0-beta-8"
+    style-value-types "^3.1.9"
+    tslib "^1.10.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@^4.0.1, framesync@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
+  integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -6273,6 +6312,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 highlight.js@~9.13.0:
   version "9.13.1"
@@ -9362,6 +9406,18 @@ polished@^3.3.1, polished@^3.6.3:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+popmotion@9.0.0-beta-8:
+  version "9.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
+  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    "@popmotion/popcorn" "^0.4.2"
+    framesync "^4.0.4"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.6"
+    tslib "^1.10.0"
+
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
@@ -11456,6 +11512,14 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
+
+style-value-types@^3.1.6, style-value-types@^3.1.7, style-value-types@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.9.tgz#faf7da660d3f284ed695cff61ea197d85b9122cc"
+  integrity sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
 
 styled-system@^5.1.5:
   version "5.1.5"


### PR DESCRIPTION
Switch to headless Tippy so we can render Arbor components instead of copying theme variables. This also adds a `title` prop and some animation, and generally cleans up the styles.