### PR TITLE
Prevent popover trigger from propagating events

### DIFF
--- a/dist/Popover/Popover.js
+++ b/dist/Popover/Popover.js
@@ -80,8 +80,18 @@ var Popover = /*#__PURE__*/function (_React$Component) {
       }
     };
 
-    _this.toggle = function () {
+    _this.toggle = function (e) {
       var isOpen = _this.state.isOpen;
+
+      if (e) {
+        if (typeof e.preventDefault === 'function') {
+          e.preventDefault();
+        }
+
+        if (typeof e.stopPropagation === 'function') {
+          e.stopPropagation();
+        }
+      }
 
       if (isOpen) {
         _this.close();

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -78,8 +78,18 @@ class Popover extends React.Component {
     this.setState({ isOpen: false }, onClose);
   }
 
-  toggle = () => {
+  toggle = (e) => {
     const { isOpen } = this.state;
+
+    if (e) {
+      if (typeof e.preventDefault === 'function') {
+        e.preventDefault();
+      }
+
+      if (typeof e.stopPropagation === 'function') {
+        e.stopPropagation();
+      }
+    }
 
     if (isOpen) {
       this.close();


### PR DESCRIPTION
This should remove some unnecessary wrapper divs in the main app:

```
const onClick = (e) => {
  e.stopPropagation();
};

    <Box onClick={onClick}>
      <Dropdown
        TriggerComponent={TriggerComponent}
        {...props}
      >
        ...
      </Dropdown>
    </Box>
```

The Box should no longer be necessary.
