### PR TITLE
Change RadioButtonGroup to send the entire event to the onChange callback, rather than just the updated value

### DIFF
--- a/dist/RadioButtonGroup/RadioButtonGroup.js
+++ b/dist/RadioButtonGroup/RadioButtonGroup.js
@@ -40,7 +40,7 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 var groupOnChange = function groupOnChange(e, setCheckedValueState, onChange) {
   var value = e.target.value;
   setCheckedValueState(value);
-  onChange(value);
+  onChange(e);
 };
 
 var RadioButtonGroup = function RadioButtonGroup(_ref) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.test.js.snap
+++ b/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.test.js.snap
@@ -66,61 +66,53 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
 >
   <StyledDateTimePicker
     className=""
-    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat={true}
+    defaultValue=""
     input={true}
     inputProps={
       Object {
         "readOnly": true,
       }
     }
-    isValidDate={[Function]}
-    onBeforeNavigate={[Function]}
-    onCalendarClose={[Function]}
-    onCalendarOpen={[Function]}
+    onBlur={[Function]}
     onChange={[Function]}
-    onClose={[Function]}
-    onNavigate={[Function]}
+    onFocus={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onOpen={[Function]}
+    onViewModeChange={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat={true}
     utc={false}
     value={2019-03-11T04:00:00.000Z}
   >
-    <n
+    <DateTime
       className=" emotion-0 emotion-1"
-      closeOnClickOutside={true}
       closeOnSelect={true}
       closeOnTab={true}
       dateFormat={true}
+      defaultValue=""
       input={true}
       inputProps={
         Object {
           "readOnly": true,
         }
       }
-      isValidDate={[Function]}
-      onBeforeNavigate={[Function]}
-      onCalendarClose={[Function]}
-      onCalendarOpen={[Function]}
+      onBlur={[Function]}
       onChange={[Function]}
-      onClose={[Function]}
-      onNavigate={[Function]}
+      onFocus={[Function]}
       onNavigateBack={[Function]}
       onNavigateForward={[Function]}
-      onOpen={[Function]}
+      onViewModeChange={[Function]}
       strictParsing={true}
       timeConstraints={Object {}}
       timeFormat={true}
       utc={false}
       value={2019-03-11T04:00:00.000Z}
     >
-      <OnClickOutside(n)
+      <OnClickOutside(Component)
         className="rdt  emotion-0 emotion-1"
         eventTypes={
           Array [
@@ -134,7 +126,7 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
         preventDefault={false}
         stopPropagation={false}
       >
-        <n
+        <Component
           className="rdt  emotion-0 emotion-1"
           disableOnClickOutside={[Function]}
           enableOnClickOutside={[Function]}
@@ -154,6 +146,7 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
           >
             <input
               className="form-control"
+              key="i"
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -164,37 +157,64 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
             />
             <div
               className="rdtPicker"
+              key="dt"
             >
-              <a
-                isValidDate={[Function]}
-                moment={[Function]}
-                navigate={[Function]}
-                selectedDate={"2019-03-11T04:00:00.000Z"}
-                showView={[Function]}
-                timeFormat="h:mm A"
-                updateDate={[Function]}
-                viewDate={"2019-03-11T04:00:00.000Z"}
+              <Component
+                view="days"
+                viewProps={
+                  Object {
+                    "addTime": [Function],
+                    "dateFormat": "MM/DD/YYYY",
+                    "handleClickOutside": [Function],
+                    "isValidDate": undefined,
+                    "localMoment": [Function],
+                    "renderDay": undefined,
+                    "renderMonth": undefined,
+                    "renderYear": undefined,
+                    "selectedDate": "2019-03-11T04:00:00.000Z",
+                    "setDate": [Function],
+                    "setTime": [Function],
+                    "showView": [Function],
+                    "subtractTime": [Function],
+                    "timeConstraints": Object {},
+                    "timeFormat": "h:mm A",
+                    "updateOn": "days",
+                    "updateSelectedDate": [Function],
+                    "value": 2019-03-11T04:00:00.000Z,
+                    "viewDate": "2019-03-01T00:00:00.000Z",
+                  }
+                }
               >
-                <div
-                  className="rdtDays"
+                <Component
+                  addTime={[Function]}
+                  dateFormat="MM/DD/YYYY"
+                  handleClickOutside={[Function]}
+                  localMoment={[Function]}
+                  selectedDate={"2019-03-11T04:00:00.000Z"}
+                  setDate={[Function]}
+                  setTime={[Function]}
+                  showView={[Function]}
+                  subtractTime={[Function]}
+                  timeConstraints={Object {}}
+                  timeFormat="h:mm A"
+                  updateOn="days"
+                  updateSelectedDate={[Function]}
+                  value={2019-03-11T04:00:00.000Z}
+                  viewDate={"2019-03-01T00:00:00.000Z"}
                 >
-                  <table>
-                    <thead>
-                      <l
-                        onClickNext={[Function]}
-                        onClickPrev={[Function]}
-                        onClickSwitch={[Function]}
-                        switchColSpan={5}
-                        switchContent="March 2019"
-                        switchProps={
-                          Object {
-                            "data-value": 2,
-                          }
-                        }
+                  <div
+                    className="rdtDays"
+                  >
+                    <table>
+                      <thead
+                        key="th"
                       >
-                        <tr>
+                        <tr
+                          key="h"
+                        >
                           <th
                             className="rdtPrev"
+                            key="p"
                             onClick={[Function]}
                           >
                             <span>
@@ -205,12 +225,14 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
                             className="rdtSwitch"
                             colSpan={5}
                             data-value={2}
+                            key="s"
                             onClick={[Function]}
                           >
                             March 2019
                           </th>
                           <th
                             className="rdtNext"
+                            key="n"
                             onClick={[Function]}
                           >
                             <span>
@@ -218,517 +240,439 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
                             </span>
                           </th>
                         </tr>
-                      </l>
-                      <tr>
-                        <th
-                          className="dow"
-                          key="Su0"
+                        <tr
+                          key="d"
                         >
-                          Su
-                        </th>
-                        <th
-                          className="dow"
-                          key="Mo1"
-                        >
-                          Mo
-                        </th>
-                        <th
-                          className="dow"
-                          key="Tu2"
-                        >
-                          Tu
-                        </th>
-                        <th
-                          className="dow"
-                          key="We3"
-                        >
-                          We
-                        </th>
-                        <th
-                          className="dow"
-                          key="Th4"
-                        >
-                          Th
-                        </th>
-                        <th
-                          className="dow"
-                          key="Fr5"
-                        >
-                          Fr
-                        </th>
-                        <th
-                          className="dow"
-                          key="Sa6"
-                        >
-                          Sa
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr
-                        key="3_0"
+                          <th
+                            className="dow"
+                            key="Su0"
+                          >
+                            Su
+                          </th>
+                          <th
+                            className="dow"
+                            key="Mo1"
+                          >
+                            Mo
+                          </th>
+                          <th
+                            className="dow"
+                            key="Tu2"
+                          >
+                            Tu
+                          </th>
+                          <th
+                            className="dow"
+                            key="We3"
+                          >
+                            We
+                          </th>
+                          <th
+                            className="dow"
+                            key="Th4"
+                          >
+                            Th
+                          </th>
+                          <th
+                            className="dow"
+                            key="Fr5"
+                          >
+                            Fr
+                          </th>
+                          <th
+                            className="dow"
+                            key="Sa6"
+                          >
+                            Sa
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody
+                        key="tb"
                       >
-                        <td
-                          className="rdtDay rdtOld"
-                          data-month={1}
-                          data-value={24}
-                          data-year={2019}
-                          key="2_24"
-                          onClick={[Function]}
-                        >
-                          24
-                        </td>
-                        <td
-                          className="rdtDay rdtOld"
-                          data-month={1}
-                          data-value={25}
-                          data-year={2019}
-                          key="2_25"
-                          onClick={[Function]}
-                        >
-                          25
-                        </td>
-                        <td
-                          className="rdtDay rdtOld"
-                          data-month={1}
-                          data-value={26}
-                          data-year={2019}
-                          key="2_26"
-                          onClick={[Function]}
-                        >
-                          26
-                        </td>
-                        <td
-                          className="rdtDay rdtOld"
-                          data-month={1}
-                          data-value={27}
-                          data-year={2019}
-                          key="2_27"
-                          onClick={[Function]}
-                        >
-                          27
-                        </td>
-                        <td
-                          className="rdtDay rdtOld"
-                          data-month={1}
-                          data-value={28}
-                          data-year={2019}
-                          key="2_28"
-                          onClick={[Function]}
-                        >
-                          28
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={1}
-                          data-year={2019}
-                          key="3_1"
-                          onClick={[Function]}
-                        >
-                          1
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={2}
-                          data-year={2019}
+                        <tr
                           key="3_2"
-                          onClick={[Function]}
                         >
-                          2
-                        </td>
-                      </tr>
-                      <tr
-                        key="3_1"
-                      >
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={3}
-                          data-year={2019}
-                          key="3_3"
-                          onClick={[Function]}
-                        >
-                          3
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={4}
-                          data-year={2019}
-                          key="3_4"
-                          onClick={[Function]}
-                        >
-                          4
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={5}
-                          data-year={2019}
-                          key="3_5"
-                          onClick={[Function]}
-                        >
-                          5
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={6}
-                          data-year={2019}
-                          key="3_6"
-                          onClick={[Function]}
-                        >
-                          6
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={7}
-                          data-year={2019}
-                          key="3_7"
-                          onClick={[Function]}
-                        >
-                          7
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={8}
-                          data-year={2019}
-                          key="3_8"
-                          onClick={[Function]}
-                        >
-                          8
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={9}
-                          data-year={2019}
+                          <td
+                            className="rdtDay rdtOld"
+                            data-value={24}
+                            key="2_24"
+                            onClick={[Function]}
+                          >
+                            24
+                          </td>
+                          <td
+                            className="rdtDay rdtOld"
+                            data-value={25}
+                            key="2_25"
+                            onClick={[Function]}
+                          >
+                            25
+                          </td>
+                          <td
+                            className="rdtDay rdtOld"
+                            data-value={26}
+                            key="2_26"
+                            onClick={[Function]}
+                          >
+                            26
+                          </td>
+                          <td
+                            className="rdtDay rdtOld"
+                            data-value={27}
+                            key="2_27"
+                            onClick={[Function]}
+                          >
+                            27
+                          </td>
+                          <td
+                            className="rdtDay rdtOld"
+                            data-value={28}
+                            key="2_28"
+                            onClick={[Function]}
+                          >
+                            28
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={1}
+                            key="3_1"
+                            onClick={[Function]}
+                          >
+                            1
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={2}
+                            key="3_2"
+                            onClick={[Function]}
+                          >
+                            2
+                          </td>
+                        </tr>
+                        <tr
                           key="3_9"
-                          onClick={[Function]}
                         >
-                          9
-                        </td>
-                      </tr>
-                      <tr
-                        key="3_2"
-                      >
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={10}
-                          data-year={2019}
-                          key="3_10"
-                          onClick={[Function]}
-                        >
-                          10
-                        </td>
-                        <td
-                          className="rdtDay rdtActive"
-                          data-month={2}
-                          data-value={11}
-                          data-year={2019}
-                          key="3_11"
-                          onClick={[Function]}
-                        >
-                          11
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={12}
-                          data-year={2019}
-                          key="3_12"
-                          onClick={[Function]}
-                        >
-                          12
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={13}
-                          data-year={2019}
-                          key="3_13"
-                          onClick={[Function]}
-                        >
-                          13
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={14}
-                          data-year={2019}
-                          key="3_14"
-                          onClick={[Function]}
-                        >
-                          14
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={15}
-                          data-year={2019}
-                          key="3_15"
-                          onClick={[Function]}
-                        >
-                          15
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={16}
-                          data-year={2019}
+                          <td
+                            className="rdtDay"
+                            data-value={3}
+                            key="3_3"
+                            onClick={[Function]}
+                          >
+                            3
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={4}
+                            key="3_4"
+                            onClick={[Function]}
+                          >
+                            4
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={5}
+                            key="3_5"
+                            onClick={[Function]}
+                          >
+                            5
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={6}
+                            key="3_6"
+                            onClick={[Function]}
+                          >
+                            6
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={7}
+                            key="3_7"
+                            onClick={[Function]}
+                          >
+                            7
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={8}
+                            key="3_8"
+                            onClick={[Function]}
+                          >
+                            8
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={9}
+                            key="3_9"
+                            onClick={[Function]}
+                          >
+                            9
+                          </td>
+                        </tr>
+                        <tr
                           key="3_16"
-                          onClick={[Function]}
                         >
-                          16
-                        </td>
-                      </tr>
-                      <tr
-                        key="3_3"
-                      >
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={17}
-                          data-year={2019}
-                          key="3_17"
-                          onClick={[Function]}
-                        >
-                          17
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={18}
-                          data-year={2019}
-                          key="3_18"
-                          onClick={[Function]}
-                        >
-                          18
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={19}
-                          data-year={2019}
-                          key="3_19"
-                          onClick={[Function]}
-                        >
-                          19
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={20}
-                          data-year={2019}
-                          key="3_20"
-                          onClick={[Function]}
-                        >
-                          20
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={21}
-                          data-year={2019}
-                          key="3_21"
-                          onClick={[Function]}
-                        >
-                          21
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={22}
-                          data-year={2019}
-                          key="3_22"
-                          onClick={[Function]}
-                        >
-                          22
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={23}
-                          data-year={2019}
+                          <td
+                            className="rdtDay"
+                            data-value={10}
+                            key="3_10"
+                            onClick={[Function]}
+                          >
+                            10
+                          </td>
+                          <td
+                            className="rdtDay rdtActive"
+                            data-value={11}
+                            key="3_11"
+                            onClick={[Function]}
+                          >
+                            11
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={12}
+                            key="3_12"
+                            onClick={[Function]}
+                          >
+                            12
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={13}
+                            key="3_13"
+                            onClick={[Function]}
+                          >
+                            13
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={14}
+                            key="3_14"
+                            onClick={[Function]}
+                          >
+                            14
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={15}
+                            key="3_15"
+                            onClick={[Function]}
+                          >
+                            15
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={16}
+                            key="3_16"
+                            onClick={[Function]}
+                          >
+                            16
+                          </td>
+                        </tr>
+                        <tr
                           key="3_23"
-                          onClick={[Function]}
                         >
-                          23
-                        </td>
-                      </tr>
-                      <tr
-                        key="3_4"
-                      >
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={24}
-                          data-year={2019}
-                          key="3_24"
-                          onClick={[Function]}
-                        >
-                          24
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={25}
-                          data-year={2019}
-                          key="3_25"
-                          onClick={[Function]}
-                        >
-                          25
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={26}
-                          data-year={2019}
-                          key="3_26"
-                          onClick={[Function]}
-                        >
-                          26
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={27}
-                          data-year={2019}
-                          key="3_27"
-                          onClick={[Function]}
-                        >
-                          27
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={28}
-                          data-year={2019}
-                          key="3_28"
-                          onClick={[Function]}
-                        >
-                          28
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={29}
-                          data-year={2019}
-                          key="3_29"
-                          onClick={[Function]}
-                        >
-                          29
-                        </td>
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={30}
-                          data-year={2019}
+                          <td
+                            className="rdtDay"
+                            data-value={17}
+                            key="3_17"
+                            onClick={[Function]}
+                          >
+                            17
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={18}
+                            key="3_18"
+                            onClick={[Function]}
+                          >
+                            18
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={19}
+                            key="3_19"
+                            onClick={[Function]}
+                          >
+                            19
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={20}
+                            key="3_20"
+                            onClick={[Function]}
+                          >
+                            20
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={21}
+                            key="3_21"
+                            onClick={[Function]}
+                          >
+                            21
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={22}
+                            key="3_22"
+                            onClick={[Function]}
+                          >
+                            22
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={23}
+                            key="3_23"
+                            onClick={[Function]}
+                          >
+                            23
+                          </td>
+                        </tr>
+                        <tr
                           key="3_30"
-                          onClick={[Function]}
                         >
-                          30
-                        </td>
-                      </tr>
-                      <tr
-                        key="3_5"
-                      >
-                        <td
-                          className="rdtDay"
-                          data-month={2}
-                          data-value={31}
-                          data-year={2019}
-                          key="3_31"
-                          onClick={[Function]}
-                        >
-                          31
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={1}
-                          data-year={2019}
-                          key="4_1"
-                          onClick={[Function]}
-                        >
-                          1
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={2}
-                          data-year={2019}
-                          key="4_2"
-                          onClick={[Function]}
-                        >
-                          2
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={3}
-                          data-year={2019}
-                          key="4_3"
-                          onClick={[Function]}
-                        >
-                          3
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={4}
-                          data-year={2019}
-                          key="4_4"
-                          onClick={[Function]}
-                        >
-                          4
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={5}
-                          data-year={2019}
-                          key="4_5"
-                          onClick={[Function]}
-                        >
-                          5
-                        </td>
-                        <td
-                          className="rdtDay rdtNew"
-                          data-month={3}
-                          data-value={6}
-                          data-year={2019}
+                          <td
+                            className="rdtDay"
+                            data-value={24}
+                            key="3_24"
+                            onClick={[Function]}
+                          >
+                            24
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={25}
+                            key="3_25"
+                            onClick={[Function]}
+                          >
+                            25
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={26}
+                            key="3_26"
+                            onClick={[Function]}
+                          >
+                            26
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={27}
+                            key="3_27"
+                            onClick={[Function]}
+                          >
+                            27
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={28}
+                            key="3_28"
+                            onClick={[Function]}
+                          >
+                            28
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={29}
+                            key="3_29"
+                            onClick={[Function]}
+                          >
+                            29
+                          </td>
+                          <td
+                            className="rdtDay"
+                            data-value={30}
+                            key="3_30"
+                            onClick={[Function]}
+                          >
+                            30
+                          </td>
+                        </tr>
+                        <tr
                           key="4_6"
-                          onClick={[Function]}
                         >
-                          6
-                        </td>
-                      </tr>
-                    </tbody>
-                    <tfoot>
-                      <tr>
-                        <td
-                          className="rdtTimeToggle"
-                          colSpan={7}
-                          onClick={[Function]}
-                        >
-                          4:00 AM
-                        </td>
-                      </tr>
-                    </tfoot>
-                  </table>
-                </div>
-              </a>
+                          <td
+                            className="rdtDay"
+                            data-value={31}
+                            key="3_31"
+                            onClick={[Function]}
+                          >
+                            31
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={1}
+                            key="4_1"
+                            onClick={[Function]}
+                          >
+                            1
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={2}
+                            key="4_2"
+                            onClick={[Function]}
+                          >
+                            2
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={3}
+                            key="4_3"
+                            onClick={[Function]}
+                          >
+                            3
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={4}
+                            key="4_4"
+                            onClick={[Function]}
+                          >
+                            4
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={5}
+                            key="4_5"
+                            onClick={[Function]}
+                          >
+                            5
+                          </td>
+                          <td
+                            className="rdtDay rdtNew"
+                            data-value={6}
+                            key="4_6"
+                            onClick={[Function]}
+                          >
+                            6
+                          </td>
+                        </tr>
+                      </tbody>
+                      <tfoot
+                        key="tf"
+                      >
+                        <tr>
+                          <td
+                            className="rdtTimeToggle"
+                            colSpan={7}
+                            onClick={[Function]}
+                          >
+                            4:00 AM
+                          </td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                  </div>
+                </Component>
+              </Component>
             </div>
           </div>
-        </n>
-      </OnClickOutside(n)>
-    </n>
+        </Component>
+      </OnClickOutside(Component)>
+    </DateTime>
   </StyledDateTimePicker>
 </DateTimePicker>
 `;

--- a/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.test.js.snap
+++ b/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.test.js.snap
@@ -66,53 +66,61 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
 >
   <StyledDateTimePicker
     className=""
+    closeOnClickOutside={true}
     closeOnSelect={true}
     closeOnTab={true}
     dateFormat={true}
-    defaultValue=""
     input={true}
     inputProps={
       Object {
         "readOnly": true,
       }
     }
-    onBlur={[Function]}
+    isValidDate={[Function]}
+    onBeforeNavigate={[Function]}
+    onCalendarClose={[Function]}
+    onCalendarOpen={[Function]}
     onChange={[Function]}
-    onFocus={[Function]}
+    onClose={[Function]}
+    onNavigate={[Function]}
     onNavigateBack={[Function]}
     onNavigateForward={[Function]}
-    onViewModeChange={[Function]}
+    onOpen={[Function]}
     strictParsing={true}
     timeConstraints={Object {}}
     timeFormat={true}
     utc={false}
     value={2019-03-11T04:00:00.000Z}
   >
-    <DateTime
+    <n
       className=" emotion-0 emotion-1"
+      closeOnClickOutside={true}
       closeOnSelect={true}
       closeOnTab={true}
       dateFormat={true}
-      defaultValue=""
       input={true}
       inputProps={
         Object {
           "readOnly": true,
         }
       }
-      onBlur={[Function]}
+      isValidDate={[Function]}
+      onBeforeNavigate={[Function]}
+      onCalendarClose={[Function]}
+      onCalendarOpen={[Function]}
       onChange={[Function]}
-      onFocus={[Function]}
+      onClose={[Function]}
+      onNavigate={[Function]}
       onNavigateBack={[Function]}
       onNavigateForward={[Function]}
-      onViewModeChange={[Function]}
+      onOpen={[Function]}
       strictParsing={true}
       timeConstraints={Object {}}
       timeFormat={true}
       utc={false}
       value={2019-03-11T04:00:00.000Z}
     >
-      <OnClickOutside(Component)
+      <OnClickOutside(n)
         className="rdt  emotion-0 emotion-1"
         eventTypes={
           Array [
@@ -126,7 +134,7 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
         preventDefault={false}
         stopPropagation={false}
       >
-        <Component
+        <n
           className="rdt  emotion-0 emotion-1"
           disableOnClickOutside={[Function]}
           enableOnClickOutside={[Function]}
@@ -146,7 +154,6 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
           >
             <input
               className="form-control"
-              key="i"
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -157,64 +164,37 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
             />
             <div
               className="rdtPicker"
-              key="dt"
             >
-              <Component
-                view="days"
-                viewProps={
-                  Object {
-                    "addTime": [Function],
-                    "dateFormat": "MM/DD/YYYY",
-                    "handleClickOutside": [Function],
-                    "isValidDate": undefined,
-                    "localMoment": [Function],
-                    "renderDay": undefined,
-                    "renderMonth": undefined,
-                    "renderYear": undefined,
-                    "selectedDate": "2019-03-11T04:00:00.000Z",
-                    "setDate": [Function],
-                    "setTime": [Function],
-                    "showView": [Function],
-                    "subtractTime": [Function],
-                    "timeConstraints": Object {},
-                    "timeFormat": "h:mm A",
-                    "updateOn": "days",
-                    "updateSelectedDate": [Function],
-                    "value": 2019-03-11T04:00:00.000Z,
-                    "viewDate": "2019-03-01T00:00:00.000Z",
-                  }
-                }
+              <a
+                isValidDate={[Function]}
+                moment={[Function]}
+                navigate={[Function]}
+                selectedDate={"2019-03-11T04:00:00.000Z"}
+                showView={[Function]}
+                timeFormat="h:mm A"
+                updateDate={[Function]}
+                viewDate={"2019-03-11T04:00:00.000Z"}
               >
-                <Component
-                  addTime={[Function]}
-                  dateFormat="MM/DD/YYYY"
-                  handleClickOutside={[Function]}
-                  localMoment={[Function]}
-                  selectedDate={"2019-03-11T04:00:00.000Z"}
-                  setDate={[Function]}
-                  setTime={[Function]}
-                  showView={[Function]}
-                  subtractTime={[Function]}
-                  timeConstraints={Object {}}
-                  timeFormat="h:mm A"
-                  updateOn="days"
-                  updateSelectedDate={[Function]}
-                  value={2019-03-11T04:00:00.000Z}
-                  viewDate={"2019-03-01T00:00:00.000Z"}
+                <div
+                  className="rdtDays"
                 >
-                  <div
-                    className="rdtDays"
-                  >
-                    <table>
-                      <thead
-                        key="th"
+                  <table>
+                    <thead>
+                      <l
+                        onClickNext={[Function]}
+                        onClickPrev={[Function]}
+                        onClickSwitch={[Function]}
+                        switchColSpan={5}
+                        switchContent="March 2019"
+                        switchProps={
+                          Object {
+                            "data-value": 2,
+                          }
+                        }
                       >
-                        <tr
-                          key="h"
-                        >
+                        <tr>
                           <th
                             className="rdtPrev"
-                            key="p"
                             onClick={[Function]}
                           >
                             <span>
@@ -225,14 +205,12 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
                             className="rdtSwitch"
                             colSpan={5}
                             data-value={2}
-                            key="s"
                             onClick={[Function]}
                           >
                             March 2019
                           </th>
                           <th
                             className="rdtNext"
-                            key="n"
                             onClick={[Function]}
                           >
                             <span>
@@ -240,439 +218,517 @@ exports[`<DateTimePicker /> properly renders a DateTimePicker 1`] = `
                             </span>
                           </th>
                         </tr>
-                        <tr
-                          key="d"
+                      </l>
+                      <tr>
+                        <th
+                          className="dow"
+                          key="Su0"
                         >
-                          <th
-                            className="dow"
-                            key="Su0"
-                          >
-                            Su
-                          </th>
-                          <th
-                            className="dow"
-                            key="Mo1"
-                          >
-                            Mo
-                          </th>
-                          <th
-                            className="dow"
-                            key="Tu2"
-                          >
-                            Tu
-                          </th>
-                          <th
-                            className="dow"
-                            key="We3"
-                          >
-                            We
-                          </th>
-                          <th
-                            className="dow"
-                            key="Th4"
-                          >
-                            Th
-                          </th>
-                          <th
-                            className="dow"
-                            key="Fr5"
-                          >
-                            Fr
-                          </th>
-                          <th
-                            className="dow"
-                            key="Sa6"
-                          >
-                            Sa
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody
-                        key="tb"
+                          Su
+                        </th>
+                        <th
+                          className="dow"
+                          key="Mo1"
+                        >
+                          Mo
+                        </th>
+                        <th
+                          className="dow"
+                          key="Tu2"
+                        >
+                          Tu
+                        </th>
+                        <th
+                          className="dow"
+                          key="We3"
+                        >
+                          We
+                        </th>
+                        <th
+                          className="dow"
+                          key="Th4"
+                        >
+                          Th
+                        </th>
+                        <th
+                          className="dow"
+                          key="Fr5"
+                        >
+                          Fr
+                        </th>
+                        <th
+                          className="dow"
+                          key="Sa6"
+                        >
+                          Sa
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr
+                        key="3_0"
                       >
-                        <tr
+                        <td
+                          className="rdtDay rdtOld"
+                          data-month={1}
+                          data-value={24}
+                          data-year={2019}
+                          key="2_24"
+                          onClick={[Function]}
+                        >
+                          24
+                        </td>
+                        <td
+                          className="rdtDay rdtOld"
+                          data-month={1}
+                          data-value={25}
+                          data-year={2019}
+                          key="2_25"
+                          onClick={[Function]}
+                        >
+                          25
+                        </td>
+                        <td
+                          className="rdtDay rdtOld"
+                          data-month={1}
+                          data-value={26}
+                          data-year={2019}
+                          key="2_26"
+                          onClick={[Function]}
+                        >
+                          26
+                        </td>
+                        <td
+                          className="rdtDay rdtOld"
+                          data-month={1}
+                          data-value={27}
+                          data-year={2019}
+                          key="2_27"
+                          onClick={[Function]}
+                        >
+                          27
+                        </td>
+                        <td
+                          className="rdtDay rdtOld"
+                          data-month={1}
+                          data-value={28}
+                          data-year={2019}
+                          key="2_28"
+                          onClick={[Function]}
+                        >
+                          28
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={1}
+                          data-year={2019}
+                          key="3_1"
+                          onClick={[Function]}
+                        >
+                          1
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={2}
+                          data-year={2019}
                           key="3_2"
+                          onClick={[Function]}
                         >
-                          <td
-                            className="rdtDay rdtOld"
-                            data-value={24}
-                            key="2_24"
-                            onClick={[Function]}
-                          >
-                            24
-                          </td>
-                          <td
-                            className="rdtDay rdtOld"
-                            data-value={25}
-                            key="2_25"
-                            onClick={[Function]}
-                          >
-                            25
-                          </td>
-                          <td
-                            className="rdtDay rdtOld"
-                            data-value={26}
-                            key="2_26"
-                            onClick={[Function]}
-                          >
-                            26
-                          </td>
-                          <td
-                            className="rdtDay rdtOld"
-                            data-value={27}
-                            key="2_27"
-                            onClick={[Function]}
-                          >
-                            27
-                          </td>
-                          <td
-                            className="rdtDay rdtOld"
-                            data-value={28}
-                            key="2_28"
-                            onClick={[Function]}
-                          >
-                            28
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={1}
-                            key="3_1"
-                            onClick={[Function]}
-                          >
-                            1
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={2}
-                            key="3_2"
-                            onClick={[Function]}
-                          >
-                            2
-                          </td>
-                        </tr>
-                        <tr
-                          key="3_9"
-                        >
-                          <td
-                            className="rdtDay"
-                            data-value={3}
-                            key="3_3"
-                            onClick={[Function]}
-                          >
-                            3
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={4}
-                            key="3_4"
-                            onClick={[Function]}
-                          >
-                            4
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={5}
-                            key="3_5"
-                            onClick={[Function]}
-                          >
-                            5
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={6}
-                            key="3_6"
-                            onClick={[Function]}
-                          >
-                            6
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={7}
-                            key="3_7"
-                            onClick={[Function]}
-                          >
-                            7
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={8}
-                            key="3_8"
-                            onClick={[Function]}
-                          >
-                            8
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={9}
-                            key="3_9"
-                            onClick={[Function]}
-                          >
-                            9
-                          </td>
-                        </tr>
-                        <tr
-                          key="3_16"
-                        >
-                          <td
-                            className="rdtDay"
-                            data-value={10}
-                            key="3_10"
-                            onClick={[Function]}
-                          >
-                            10
-                          </td>
-                          <td
-                            className="rdtDay rdtActive"
-                            data-value={11}
-                            key="3_11"
-                            onClick={[Function]}
-                          >
-                            11
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={12}
-                            key="3_12"
-                            onClick={[Function]}
-                          >
-                            12
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={13}
-                            key="3_13"
-                            onClick={[Function]}
-                          >
-                            13
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={14}
-                            key="3_14"
-                            onClick={[Function]}
-                          >
-                            14
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={15}
-                            key="3_15"
-                            onClick={[Function]}
-                          >
-                            15
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={16}
-                            key="3_16"
-                            onClick={[Function]}
-                          >
-                            16
-                          </td>
-                        </tr>
-                        <tr
-                          key="3_23"
-                        >
-                          <td
-                            className="rdtDay"
-                            data-value={17}
-                            key="3_17"
-                            onClick={[Function]}
-                          >
-                            17
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={18}
-                            key="3_18"
-                            onClick={[Function]}
-                          >
-                            18
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={19}
-                            key="3_19"
-                            onClick={[Function]}
-                          >
-                            19
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={20}
-                            key="3_20"
-                            onClick={[Function]}
-                          >
-                            20
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={21}
-                            key="3_21"
-                            onClick={[Function]}
-                          >
-                            21
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={22}
-                            key="3_22"
-                            onClick={[Function]}
-                          >
-                            22
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={23}
-                            key="3_23"
-                            onClick={[Function]}
-                          >
-                            23
-                          </td>
-                        </tr>
-                        <tr
-                          key="3_30"
-                        >
-                          <td
-                            className="rdtDay"
-                            data-value={24}
-                            key="3_24"
-                            onClick={[Function]}
-                          >
-                            24
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={25}
-                            key="3_25"
-                            onClick={[Function]}
-                          >
-                            25
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={26}
-                            key="3_26"
-                            onClick={[Function]}
-                          >
-                            26
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={27}
-                            key="3_27"
-                            onClick={[Function]}
-                          >
-                            27
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={28}
-                            key="3_28"
-                            onClick={[Function]}
-                          >
-                            28
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={29}
-                            key="3_29"
-                            onClick={[Function]}
-                          >
-                            29
-                          </td>
-                          <td
-                            className="rdtDay"
-                            data-value={30}
-                            key="3_30"
-                            onClick={[Function]}
-                          >
-                            30
-                          </td>
-                        </tr>
-                        <tr
-                          key="4_6"
-                        >
-                          <td
-                            className="rdtDay"
-                            data-value={31}
-                            key="3_31"
-                            onClick={[Function]}
-                          >
-                            31
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={1}
-                            key="4_1"
-                            onClick={[Function]}
-                          >
-                            1
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={2}
-                            key="4_2"
-                            onClick={[Function]}
-                          >
-                            2
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={3}
-                            key="4_3"
-                            onClick={[Function]}
-                          >
-                            3
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={4}
-                            key="4_4"
-                            onClick={[Function]}
-                          >
-                            4
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={5}
-                            key="4_5"
-                            onClick={[Function]}
-                          >
-                            5
-                          </td>
-                          <td
-                            className="rdtDay rdtNew"
-                            data-value={6}
-                            key="4_6"
-                            onClick={[Function]}
-                          >
-                            6
-                          </td>
-                        </tr>
-                      </tbody>
-                      <tfoot
-                        key="tf"
+                          2
+                        </td>
+                      </tr>
+                      <tr
+                        key="3_1"
                       >
-                        <tr>
-                          <td
-                            className="rdtTimeToggle"
-                            colSpan={7}
-                            onClick={[Function]}
-                          >
-                            4:00 AM
-                          </td>
-                        </tr>
-                      </tfoot>
-                    </table>
-                  </div>
-                </Component>
-              </Component>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={3}
+                          data-year={2019}
+                          key="3_3"
+                          onClick={[Function]}
+                        >
+                          3
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={4}
+                          data-year={2019}
+                          key="3_4"
+                          onClick={[Function]}
+                        >
+                          4
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={5}
+                          data-year={2019}
+                          key="3_5"
+                          onClick={[Function]}
+                        >
+                          5
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={6}
+                          data-year={2019}
+                          key="3_6"
+                          onClick={[Function]}
+                        >
+                          6
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={7}
+                          data-year={2019}
+                          key="3_7"
+                          onClick={[Function]}
+                        >
+                          7
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={8}
+                          data-year={2019}
+                          key="3_8"
+                          onClick={[Function]}
+                        >
+                          8
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={9}
+                          data-year={2019}
+                          key="3_9"
+                          onClick={[Function]}
+                        >
+                          9
+                        </td>
+                      </tr>
+                      <tr
+                        key="3_2"
+                      >
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={10}
+                          data-year={2019}
+                          key="3_10"
+                          onClick={[Function]}
+                        >
+                          10
+                        </td>
+                        <td
+                          className="rdtDay rdtActive"
+                          data-month={2}
+                          data-value={11}
+                          data-year={2019}
+                          key="3_11"
+                          onClick={[Function]}
+                        >
+                          11
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={12}
+                          data-year={2019}
+                          key="3_12"
+                          onClick={[Function]}
+                        >
+                          12
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={13}
+                          data-year={2019}
+                          key="3_13"
+                          onClick={[Function]}
+                        >
+                          13
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={14}
+                          data-year={2019}
+                          key="3_14"
+                          onClick={[Function]}
+                        >
+                          14
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={15}
+                          data-year={2019}
+                          key="3_15"
+                          onClick={[Function]}
+                        >
+                          15
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={16}
+                          data-year={2019}
+                          key="3_16"
+                          onClick={[Function]}
+                        >
+                          16
+                        </td>
+                      </tr>
+                      <tr
+                        key="3_3"
+                      >
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={17}
+                          data-year={2019}
+                          key="3_17"
+                          onClick={[Function]}
+                        >
+                          17
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={18}
+                          data-year={2019}
+                          key="3_18"
+                          onClick={[Function]}
+                        >
+                          18
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={19}
+                          data-year={2019}
+                          key="3_19"
+                          onClick={[Function]}
+                        >
+                          19
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={20}
+                          data-year={2019}
+                          key="3_20"
+                          onClick={[Function]}
+                        >
+                          20
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={21}
+                          data-year={2019}
+                          key="3_21"
+                          onClick={[Function]}
+                        >
+                          21
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={22}
+                          data-year={2019}
+                          key="3_22"
+                          onClick={[Function]}
+                        >
+                          22
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={23}
+                          data-year={2019}
+                          key="3_23"
+                          onClick={[Function]}
+                        >
+                          23
+                        </td>
+                      </tr>
+                      <tr
+                        key="3_4"
+                      >
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={24}
+                          data-year={2019}
+                          key="3_24"
+                          onClick={[Function]}
+                        >
+                          24
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={25}
+                          data-year={2019}
+                          key="3_25"
+                          onClick={[Function]}
+                        >
+                          25
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={26}
+                          data-year={2019}
+                          key="3_26"
+                          onClick={[Function]}
+                        >
+                          26
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={27}
+                          data-year={2019}
+                          key="3_27"
+                          onClick={[Function]}
+                        >
+                          27
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={28}
+                          data-year={2019}
+                          key="3_28"
+                          onClick={[Function]}
+                        >
+                          28
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={29}
+                          data-year={2019}
+                          key="3_29"
+                          onClick={[Function]}
+                        >
+                          29
+                        </td>
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={30}
+                          data-year={2019}
+                          key="3_30"
+                          onClick={[Function]}
+                        >
+                          30
+                        </td>
+                      </tr>
+                      <tr
+                        key="3_5"
+                      >
+                        <td
+                          className="rdtDay"
+                          data-month={2}
+                          data-value={31}
+                          data-year={2019}
+                          key="3_31"
+                          onClick={[Function]}
+                        >
+                          31
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={1}
+                          data-year={2019}
+                          key="4_1"
+                          onClick={[Function]}
+                        >
+                          1
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={2}
+                          data-year={2019}
+                          key="4_2"
+                          onClick={[Function]}
+                        >
+                          2
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={3}
+                          data-year={2019}
+                          key="4_3"
+                          onClick={[Function]}
+                        >
+                          3
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={4}
+                          data-year={2019}
+                          key="4_4"
+                          onClick={[Function]}
+                        >
+                          4
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={5}
+                          data-year={2019}
+                          key="4_5"
+                          onClick={[Function]}
+                        >
+                          5
+                        </td>
+                        <td
+                          className="rdtDay rdtNew"
+                          data-month={3}
+                          data-value={6}
+                          data-year={2019}
+                          key="4_6"
+                          onClick={[Function]}
+                        >
+                          6
+                        </td>
+                      </tr>
+                    </tbody>
+                    <tfoot>
+                      <tr>
+                        <td
+                          className="rdtTimeToggle"
+                          colSpan={7}
+                          onClick={[Function]}
+                        >
+                          4:00 AM
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              </a>
             </div>
           </div>
-        </Component>
-      </OnClickOutside(Component)>
-    </DateTime>
+        </n>
+      </OnClickOutside(n)>
+    </n>
   </StyledDateTimePicker>
 </DateTimePicker>
 `;

--- a/src/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/RadioButtonGroup/RadioButtonGroup.js
@@ -8,7 +8,7 @@ const groupOnChange = (e, setCheckedValueState, onChange) => {
     target: { value }
   } = e;
   setCheckedValueState(value);
-  onChange(value);
+  onChange(e);
 };
 
 const RadioButtonGroup = ({

--- a/src/RadioButtonGroup/__tests__/RadioButtonGroup.test.js
+++ b/src/RadioButtonGroup/__tests__/RadioButtonGroup.test.js
@@ -66,12 +66,10 @@ describe('<RadioButtonGroup />', () => {
 
   it('calls the passed onChange when one of the items is clicked', () => {
     const wrapper = shallow(<RadioButtonGroup {...{ ...baseProps }} />);
+    const event = { target: { value: options[1].value } };
 
-    wrapper
-      .find(RadioButton)
-      .at(1)
-      .simulate('change', { target: { value: options[1].value } });
+    wrapper.find(RadioButton).at(1).simulate('change', event);
 
-    expect(onChange).toHaveBeenLastCalledWith(options[1].value);
+    expect(onChange).toHaveBeenLastCalledWith(event);
   });
 });


### PR DESCRIPTION
We have only 1 use of this in the app right now, which is easily updated for this change.

I'm making this change so the interface is consistent with other form field types we use in arbor, since the reach out sequence stuff is config-driven. Without this, it requires hard-coding an onChange in the frontend for each radio button group in the response form, which is highly undesirable.