### PR TITLE
export media queries based on the breakpoints, to ease their use in very-custom styling

### DIFF
--- a/dist/theme/index.js
+++ b/dist/theme/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = exports.boxShadows = exports.borderWidth = exports.borderRadius = exports.spacings = exports.lineHeights = exports.icons = exports.colors = exports.bronzes = exports.black = exports.greens = exports.reds = exports.whites = exports.greys = exports.blues = exports.breakpoints = exports.breakpointsMap = void 0;
+exports["default"] = exports.boxShadows = exports.borderWidth = exports.borderRadius = exports.spacings = exports.lineHeights = exports.icons = exports.colors = exports.bronzes = exports.black = exports.greens = exports.reds = exports.whites = exports.greys = exports.blues = exports.mediaQueries = exports.breakpoints = exports.breakpointsMap = void 0;
 
 var _polished = require("polished");
 
@@ -35,6 +35,13 @@ breakpoints.sm = breakpointsMap.sm;
 breakpoints.md = breakpointsMap.md;
 breakpoints.lg = breakpointsMap.lg;
 breakpoints.xl = breakpointsMap.xl;
+var mediaQueries = {
+  sm: "@media screen and (min-width: ".concat(breakpointsMap.sm, ")"),
+  md: "@media screen and (min-width: ".concat(breakpointsMap.md, ")"),
+  lg: "@media screen and (min-width: ".concat(breakpointsMap.lg, ")"),
+  xl: "@media screen and (min-width: ".concat(breakpointsMap.xl, ")")
+};
+exports.mediaQueries = mediaQueries;
 var blues = {
   blueLighter: '#6688FF',
   blueLight: '#5577FF',
@@ -179,6 +186,7 @@ var _default = {
   icons: icons,
   iconFontPrefix: 'ar',
   lineHeights: lineHeights,
+  mediaQueries: mediaQueries,
   radii: borderRadius,
   shadows: boxShadows,
   space: spacings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.96.1",
+  "version": "0.96.2",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ProgressBar/__tests__/__snapshots__/ProgressBar.test.js.snap
+++ b/src/ProgressBar/__tests__/__snapshots__/ProgressBar.test.js.snap
@@ -532,6 +532,12 @@ exports[`<ProgressBar /> renders the progress bar properly 1`] = `
                   "regular": 1,
                   "small": 1.25,
                 },
+                "mediaQueries": Object {
+                  "lg": "@media screen and (min-width: 1024px)",
+                  "md": "@media screen and (min-width: 768px)",
+                  "sm": "@media screen and (min-width: 512px)",
+                  "xl": "@media screen and (min-width: 1600px)",
+                },
                 "radii": Object {
                   "large": "6px",
                   "larger": "12px",
@@ -1111,6 +1117,12 @@ exports[`<ProgressBar /> renders the progress bar properly at 100% with an icon 
                   "large": 1.5,
                   "regular": 1,
                   "small": 1.25,
+                },
+                "mediaQueries": Object {
+                  "lg": "@media screen and (min-width: 1024px)",
+                  "md": "@media screen and (min-width: 768px)",
+                  "sm": "@media screen and (min-width: 512px)",
+                  "xl": "@media screen and (min-width: 1600px)",
                 },
                 "radii": Object {
                   "large": "6px",

--- a/src/Spinner/__tests__/__snapshots__/Spinner.test.js.snap
+++ b/src/Spinner/__tests__/__snapshots__/Spinner.test.js.snap
@@ -367,6 +367,12 @@ exports[`<Spinner /> spinner is not spinning properly renders a spinner 1`] = `
           "regular": 1,
           "small": 1.25,
         },
+        "mediaQueries": Object {
+          "lg": "@media screen and (min-width: 1024px)",
+          "md": "@media screen and (min-width: 768px)",
+          "sm": "@media screen and (min-width: 512px)",
+          "xl": "@media screen and (min-width: 1600px)",
+        },
         "radii": Object {
           "large": "6px",
           "larger": "12px",
@@ -924,6 +930,12 @@ exports[`<Spinner /> spinner is spinning properly renders a spinner 1`] = `
           "regular": 1,
           "small": 1.25,
         },
+        "mediaQueries": Object {
+          "lg": "@media screen and (min-width: 1024px)",
+          "md": "@media screen and (min-width: 768px)",
+          "sm": "@media screen and (min-width: 512px)",
+          "xl": "@media screen and (min-width: 1600px)",
+        },
         "radii": Object {
           "large": "6px",
           "larger": "12px",
@@ -1309,6 +1321,12 @@ exports[`<Spinner /> spinner is spinning properly renders a spinner 1`] = `
             "large": 1.5,
             "regular": 1,
             "small": 1.25,
+          },
+          "mediaQueries": Object {
+            "lg": "@media screen and (min-width: 1024px)",
+            "md": "@media screen and (min-width: 768px)",
+            "sm": "@media screen and (min-width: 512px)",
+            "xl": "@media screen and (min-width: 1600px)",
           },
           "radii": Object {
             "large": "6px",
@@ -1983,6 +2001,12 @@ exports[`<Spinner /> spinner is spinning theme color is provided properly render
           "regular": 1,
           "small": 1.25,
         },
+        "mediaQueries": Object {
+          "lg": "@media screen and (min-width: 1024px)",
+          "md": "@media screen and (min-width: 768px)",
+          "sm": "@media screen and (min-width: 512px)",
+          "xl": "@media screen and (min-width: 1600px)",
+        },
         "radii": Object {
           "large": "6px",
           "larger": "12px",
@@ -2368,6 +2392,12 @@ exports[`<Spinner /> spinner is spinning theme color is provided properly render
             "large": 1.5,
             "regular": 1,
             "small": 1.25,
+          },
+          "mediaQueries": Object {
+            "lg": "@media screen and (min-width: 1024px)",
+            "md": "@media screen and (min-width: 768px)",
+            "sm": "@media screen and (min-width: 512px)",
+            "xl": "@media screen and (min-width: 1600px)",
           },
           "radii": Object {
             "large": "6px",

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -36,6 +36,13 @@ breakpoints.md = breakpointsMap.md;
 breakpoints.lg = breakpointsMap.lg;
 breakpoints.xl = breakpointsMap.xl;
 
+export const mediaQueries = {
+  sm: `@media screen and (min-width: ${breakpointsMap.sm})`,
+  md: `@media screen and (min-width: ${breakpointsMap.md})`,
+  lg: `@media screen and (min-width: ${breakpointsMap.lg})`,
+  xl: `@media screen and (min-width: ${breakpointsMap.xl})`
+};
+
 export const blues = {
   blueLighter: '#6688FF',
   blueLight: '#5577FF',
@@ -185,6 +192,7 @@ export default {
   icons,
   iconFontPrefix: 'ar',
   lineHeights,
+  mediaQueries,
   radii: borderRadius,
   shadows: boxShadows,
   space: spacings


### PR DESCRIPTION
I have need in the monolith to flip a particular style based on screen-width, but i don't want to just add these kinds of one-offs one at a time to the arbor exports. Exporting these queries directly lets us write custom `css` props with this information as well.

This is just based on https://styled-system.com/theme-specification/#media-queries