### PR TITLE
Hide arrows added by browsers

### DIFF
--- a/src/Input/inputStyles.js
+++ b/src/Input/inputStyles.js
@@ -16,6 +16,17 @@ const invalidStyles = (theme) => css`
   background: ${theme.colors.palette.red.lighter};
 `;
 
+/* stylelint-disable property-no-vendor-prefix */
+const hideArrowsAddedByBrowsers = css`
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  -moz-appearance: textfield;
+`;
+/* stylelint-enable property-no-vendor-prefix */
+
 const inputStyles = ({ isDisabled, isFocused, isInvalid, theme }) => css`
   border-radius: ${theme.radii.small};
   border: ${theme.borderWidth.small} solid ${theme.colors.border.default};
@@ -50,6 +61,8 @@ const inputStyles = ({ isDisabled, isFocused, isInvalid, theme }) => css`
   &:required {
     box-shadow: none;
   }
+
+  ${hideArrowsAddedByBrowsers}
 `;
 
 export default inputStyles;

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -51,6 +51,13 @@ storiesOf('Input', module).add(
         name="email"
       />
       <Input
+        label="Number Field"
+        id="number-field"
+        type="number"
+        placeholder="12345"
+        name="number"
+      />
+      <Input
         label="Disabled"
         id="disabled-input"
         disabled


### PR DESCRIPTION
Remove arrows added by browsers.

At first I thought about making this configurable. But I couldn't think of any scenario where we'd ever rely on these arrows for functionality. Users could always enter information in this field using their keyboard.


**Before (Chrome):**

![Screen Shot 2021-03-11 at 1 59 07 PM](https://user-images.githubusercontent.com/6894325/110863710-f0f05980-8275-11eb-8427-675a4983e6c4.png)


**Before (Firefox):**

![Screen Shot 2021-03-11 at 1 58 55 PM](https://user-images.githubusercontent.com/6894325/110863826-1aa98080-8276-11eb-8a36-1629e5bd05a5.png)


**After (Both, they look the same):**

![Screen Shot 2021-03-11 at 1 59 27 PM](https://user-images.githubusercontent.com/6894325/110863852-25641580-8276-11eb-81ae-eff1e6221baf.png)
