### PR TITLE
Ted/allow node as label for select

### DIFF
--- a/dist/FormField/FormField.js
+++ b/dist/FormField/FormField.js
@@ -63,7 +63,7 @@ FormField.propTypes = {
   /**
    * Label text for the form field
    */
-  label: _propTypes["default"].string,
+  label: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].string]),
 
   /**
    * Component that goes to the right of the label. Does not have to only be text.

--- a/dist/Select/Select.js
+++ b/dist/Select/Select.js
@@ -65,7 +65,7 @@ Select.propTypes = {
   /**
    * Label text for the select
    */
-  label: _propTypes["default"].string,
+  label: _propTypes["default"].oneOfType([_propTypes["default"].node, _propTypes["default"].string]),
 
   /**
    * Component that goes to the right of the label. Does not have to only be text.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.96.5",
+  "version": "0.96.6",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FormField/FormField.js
+++ b/src/FormField/FormField.js
@@ -48,7 +48,7 @@ FormField.propTypes = {
   /**
    * Label text for the form field
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 
   /**
    * Component that goes to the right of the label. Does not have to only be text.

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -47,7 +47,7 @@ Select.propTypes = {
   /**
    * Label text for the select
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 
   /**
    * Component that goes to the right of the label. Does not have to only be text.

--- a/stories/select.stories.js
+++ b/stories/select.stories.js
@@ -53,7 +53,7 @@ storiesOf('Select', module).add(
         id="select-with-node-label"
         label={
           <Flex>
-            <Text>Role</Text>
+            <Text>Select w/ tooltip</Text>
             <Tooltip content="This is a tooltip">
               <Icon name="info-sign" color="icon.default" ml="smallest" />
             </Tooltip>

--- a/stories/select.stories.js
+++ b/stories/select.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import notes from './select.md';
-import { Select } from '../src';
+import { Flex, Icon, Select, Text, Tooltip } from '../src';
 
 const options = (
   <>
@@ -45,6 +45,21 @@ storiesOf('Select', module).add(
         large
         name="large-select"
         placeholder="Placeholder"
+      >
+        {options}
+      </Select>
+      <Select
+        defaultValue="yes"
+        id="select-with-node-label"
+        label={
+          <Flex>
+            <Text>Role</Text>
+            <Tooltip content="This is a tooltip">
+              <Icon name="info-sign" color="icon.default" ml="smallest" />
+            </Tooltip>
+          </Flex>
+        }
+        name="disabled-select"
       >
         {options}
       </Select>


### PR DESCRIPTION
**PROBLEM:**

```
Warning: Failed prop type: Invalid prop `label` of type `object` supplied to `ForwardRef`, expected `string`
```

Arbor expects `label`s to always be a string and therefore didn't like it when we would pass in things like texts w/ tooltips.

**SOLUTION:**

Allow `node` to be passed in as `label`.

<img width="464" alt="Screen Shot 2021-03-16 at 9 31 43 AM" src="https://user-images.githubusercontent.com/6894325/111345357-71c6a100-863a-11eb-8e5b-564925dc3dae.png">

Pivotal: 177349368