### PR TITLE
Add addon-essentials and convert from knobs to controls

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,7 +10,6 @@ module.exports = {
       }
     },
     '@storybook/addon-links',
-    '@storybook/addon-knobs',
     '@storybook/addon-a11y',
     '@storybook/addon-notes'
   ],

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,6 @@ module.exports = {
     {
       name: '@storybook/addon-essentials',
       options: {
-        controls: false,
         docs: false
       }
     },

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,6 @@ module.exports = {
         docs: false
       }
     },
-    '@storybook/addon-links',
     '@storybook/addon-a11y',
     '@storybook/addon-notes'
   ],

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,13 @@ const path = require('path');
 module.exports = {
   stories: ['../stories/**/*.stories.js'],
   addons: [
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        controls: false,
+        docs: false
+      }
+    },
     '@storybook/addon-links',
     '@storybook/addon-knobs',
     '@storybook/addon-a11y',

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@emotion/snapshot-serializer": "^0.8.2",
     "@storybook/addon-a11y": "^6.1.21",
     "@storybook/addon-essentials": "^6.1.21",
-    "@storybook/addon-knobs": "^6.1.21",
     "@storybook/addon-links": "^6.1.21",
     "@storybook/addon-notes": "^5.3.21",
     "@storybook/addons": "^6.1.21",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@emotion/snapshot-serializer": "^0.8.2",
     "@storybook/addon-a11y": "^6.1.21",
     "@storybook/addon-essentials": "^6.1.21",
-    "@storybook/addon-links": "^6.1.21",
     "@storybook/addon-notes": "^5.3.21",
     "@storybook/addons": "^6.1.21",
     "@storybook/react": "^6.1.21",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@emotion/jest": "^11.2.1",
     "@emotion/snapshot-serializer": "^0.8.2",
     "@storybook/addon-a11y": "^6.1.21",
+    "@storybook/addon-essentials": "^6.1.21",
     "@storybook/addon-knobs": "^6.1.21",
     "@storybook/addon-links": "^6.1.21",
     "@storybook/addon-notes": "^5.3.21",

--- a/stories/accordion.stories.js
+++ b/stories/accordion.stories.js
@@ -331,7 +331,5 @@ export const Default = () => {
   );
 };
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/accordion.stories.js
+++ b/stories/accordion.stories.js
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 
 import { forceReRender } from '@storybook/react';
-import { boolean, select } from '@storybook/addon-knobs';
 
 import notes from './accordion.md';
 import {
@@ -43,17 +42,31 @@ const doAlert = (msg) => window.alert(msg); // eslint-disable-line no-alert, no-
 const variantOptions = ['default', 'minimal'];
 
 export default {
-  title: 'Accordion'
+  title: 'Accordion',
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+        options: buttonOptions
+      }
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: variantOptions
+      }
+    }
+  }
 };
 
-export const Default = () => {
-  const sizeSelect = select('Size', buttonOptions, defaultButtonSize);
+export const Default = (args) => {
+  const { size, variant } = args;
 
   const noteWithButtons = (
     <Box my="smallest">
       <Button
         variant="minimal"
-        size={sizeSelect}
+        size={size}
         iconStart={annotationIcon}
         onClick={(e) => {
           doAlert('message');
@@ -64,7 +77,7 @@ export const Default = () => {
       </Button>
       <Button
         variant="minimal"
-        size={sizeSelect}
+        size={size}
         iconStart={trashIcon}
         aria-label="Delete"
         onClick={(e) => {
@@ -79,7 +92,7 @@ export const Default = () => {
     <Box my="smallest">
       <Button
         variant="secondary"
-        size={sizeSelect}
+        size={size}
         onClick={(e) => {
           doAlert('secondary');
           e.stopPropagation();
@@ -89,7 +102,7 @@ export const Default = () => {
       </Button>
       <Button
         variant="primary"
-        size={sizeSelect}
+        size={size}
         onClick={(e) => {
           doAlert('primary');
           e.stopPropagation();
@@ -104,7 +117,7 @@ export const Default = () => {
     <Box my="smallest">
       <Button
         variant="minimal"
-        size={sizeSelect}
+        size={size}
         onClick={(e) => {
           doAlert('minimal');
           e.stopPropagation();
@@ -114,7 +127,7 @@ export const Default = () => {
       </Button>
       <Button
         variant="secondary"
-        size={sizeSelect}
+        size={size}
         onClick={(e) => {
           doAlert('secondary');
           e.stopPropagation();
@@ -141,10 +154,10 @@ export const Default = () => {
             <AccordionSection
               header={<Box my="small">Header 1: Controlled</Box>}
               headerNote={note}
-              isOpen={boolean('isOpen', isOpen)}
+              isOpen={args.isOpen}
               onHeaderClick={onHeaderClick}
               panelId="header-1-controlled"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Text mb="regular">
@@ -165,7 +178,7 @@ export const Default = () => {
               header={<Box my="small">Header 2: Uncontrolled </Box>}
               headerNote={note}
               panelId="header-2-uncontrolled"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Text mb="regular">
@@ -187,7 +200,7 @@ export const Default = () => {
                 <Box my="small">Header 3: Multiple Sections of Content</Box>
               }
               panelId="header-3-uncontrolled"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Heading.H2>Section 1</Heading.H2>
@@ -259,7 +272,7 @@ export const Default = () => {
               header={<Box my="small">Header with minimal buttons</Box>}
               headerNote={noteWithButtons}
               panelId="minimal-button-notes-panel-1"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Text>
@@ -285,7 +298,7 @@ export const Default = () => {
               header={<Box my="small">Header with primary buttons</Box>}
               headerNote={noteWithPrimaryButtons}
               panelId="primary-buttons-panel-1"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Text>
@@ -311,7 +324,7 @@ export const Default = () => {
               header={<Box my="small">Header with secondary buttons</Box>}
               headerNote={noteWithSecondaryButtons}
               panelId="secondary-buttons-panel-1"
-              variant={select('Variant', variantOptions)}
+              variant={variant}
             >
               <Box p="regular">
                 <Text>
@@ -331,5 +344,6 @@ export const Default = () => {
   );
 };
 
+Default.args = { isOpen, size: defaultButtonSize, variant: variantOptions[0] };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/alert.stories.js
+++ b/stories/alert.stories.js
@@ -34,9 +34,7 @@ export const Banner = () => (
   </Box>
 );
 
-Banner.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Banner.parameters = { notes: { markdown: notes } };
 
 export const Card = () => (
   <Box as="section" p="regular">
@@ -57,9 +55,7 @@ export const Card = () => (
   </Box>
 );
 
-Card.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Card.parameters = { notes: { markdown: notes } };
 
 export const Inline = () => (
   <Box as="section" p="regular">
@@ -77,9 +73,7 @@ export const Inline = () => (
   </Box>
 );
 
-Inline.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Inline.parameters = { notes: { markdown: notes } };
 
 export const Pane = () => (
   <Box as="section" p="regular">
@@ -100,9 +94,7 @@ export const Pane = () => (
   </Box>
 );
 
-Pane.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Pane.parameters = { notes: { markdown: notes } };
 
 export const Toast = () => (
   <Box as="section" p="regular">
@@ -123,6 +115,4 @@ export const Toast = () => (
   </Box>
 );
 
-Toast.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Toast.parameters = { notes: { markdown: notes } };

--- a/stories/alert.stories.js
+++ b/stories/alert.stories.js
@@ -1,5 +1,3 @@
-import { select, text } from '@storybook/addon-knobs';
-
 import notes from './alert.md';
 import {
   BannerAlert,
@@ -12,107 +10,103 @@ import {
 } from '../src';
 import INTENTS from '../src/Alert/intents';
 
-const ON_CLOSE_OPTIONS = ['', () => alert('Close Me!')]; // eslint-disable-line no-alert, no-undef
+const ON_CLOSE_OPTIONS = [null, () => alert('Close Me!')]; // eslint-disable-line no-alert, no-undef
 
 export default {
-  title: 'Alerts'
+  title: 'Alerts',
+  argTypes: {
+    intent: {
+      name: 'intent',
+      control: {
+        type: 'select',
+        options: INTENTS
+      }
+    },
+    onClose: {
+      name: 'onClose',
+      control: {
+        type: 'select',
+        options: ON_CLOSE_OPTIONS
+      }
+    }
+  }
 };
 
-export const Banner = () => (
+export const Banner = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Banner Alert</Heading.H1>
 
-    <BannerAlert
-      details={text(
-        'Details',
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.'
-      )}
-      intent={select('Intent', INTENTS, INTENTS[0])}
-      message={text('Message', 'Hooray!')}
-      onClose={select('On Close', ON_CLOSE_OPTIONS)}
-    />
+    <BannerAlert {...args} />
   </Box>
 );
 
+Banner.args = {
+  details:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.',
+  intent: INTENTS[0],
+  message: 'Hooray!'
+};
 Banner.parameters = { notes: { markdown: notes } };
 
-export const Card = () => (
+export const Card = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Card Alert</Heading.H1>
 
-    <CardAlert
-      details={text(
-        'Details',
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-      )}
-      intent={select('Intent', [...INTENTS, ''], INTENTS[0])}
-      message={text(
-        'Message',
-        'Hooray! You did it. Your Source is now sending data.'
-      )}
-      onClose={select('On Close', ON_CLOSE_OPTIONS)}
-    />
+    <CardAlert {...args} />
   </Box>
 );
 
+Card.args = {
+  details:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  intent: INTENTS[0],
+  message: 'Hooray! You did it. Your Source is now sending data.'
+};
 Card.parameters = { notes: { markdown: notes } };
 
-export const Inline = () => (
+export const Inline = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Box Alert</Heading.H1>
 
-    <InlineAlert
-      details={text('Details', '')}
-      intent={select('Intent', INTENTS, INTENTS[0])}
-      message={text(
-        'Message',
-        'Hooray! You did it. Your Source is now sending data.'
-      )}
-      onClose={select('On Close', ON_CLOSE_OPTIONS)}
-    />
+    <InlineAlert {...args} />
   </Box>
 );
 
+Inline.args = {
+  details: '',
+  intent: INTENTS[0],
+  message: 'Hooray! You did it. Your Source is now sending data.'
+};
 Inline.parameters = { notes: { markdown: notes } };
 
-export const Pane = () => (
+export const Pane = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Pane Alert</Heading.H1>
 
-    <PaneAlert
-      details={text(
-        'Details',
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-      )}
-      intent={select('Intent', [...INTENTS, ''], INTENTS[0])}
-      message={text(
-        'Message',
-        'Hooray! You did it. Your Source is now sending data.'
-      )}
-      onClose={select('On Close', ON_CLOSE_OPTIONS)}
-    />
+    <PaneAlert {...args} />
   </Box>
 );
 
+Pane.args = {
+  details:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  intent: INTENTS[0],
+  message: 'Hooray! You did it. Your Source is now sending data.'
+};
 Pane.parameters = { notes: { markdown: notes } };
 
-export const Toast = () => (
+export const Toast = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Toast Alert</Heading.H1>
 
-    <ToastAlert
-      details={text(
-        'Details',
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-      )}
-      intent={select('Intent', [...INTENTS, ''], INTENTS[0])}
-      message={text(
-        'Message',
-        'Hooray! You did it. Your Source is now sending data.'
-      )}
-      onClose={select('On Close', ON_CLOSE_OPTIONS)}
-    />
+    <ToastAlert {...args} />
   </Box>
 );
 
+Toast.args = {
+  details:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  intent: INTENTS[0],
+  message: 'Hooray! You did it. Your Source is now sending data.'
+};
 Toast.parameters = { notes: { markdown: notes } };

--- a/stories/autoComplete.stories.js
+++ b/stories/autoComplete.stories.js
@@ -202,7 +202,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/autoComplete.stories.js
+++ b/stories/autoComplete.stories.js
@@ -1,6 +1,5 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { boolean, select } from '@storybook/addon-knobs';
 
 import { styledAutoCompleteComponents } from '../src/AutoComplete';
 import notes from './autoComplete.md';
@@ -89,17 +88,15 @@ class AutoCompleteExample extends Component {
 
   render() {
     const { selectedOption } = this.state;
+    const { isMulti } = this.props;
+
+    const caption = `Select one ${isMulti ? 'or more values' : 'value'}`;
 
     return (
       <Box mb="larger">
         <AutoComplete
           {...{
-            caption: `Select one ${
-              boolean('isMulti', true) ? 'or more values' : 'value'
-            }`,
-            hideDropdownIndicator: boolean('hideDropdownIndicator', false),
-            isMulti: boolean('isMulti', true),
-            isDisabled: boolean('isDisabled', false),
+            caption,
             onChange: this.handleChange,
             value: selectedOption,
             ...this.additionalProps,
@@ -112,6 +109,7 @@ class AutoCompleteExample extends Component {
 }
 
 AutoCompleteExample.propTypes = {
+  isMulti: PropTypes.bool.isRequired,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
   variant: PropTypes.string
 };
@@ -121,10 +119,18 @@ AutoCompleteExample.defaultProps = {
 };
 
 export default {
-  title: 'AutoComplete'
+  title: 'AutoComplete',
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: variantOptions
+      }
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>AutoComplete</Heading.H1>
 
@@ -132,7 +138,7 @@ export const Default = () => (
       id="auto-complete-1"
       label="AutoComplete with unstyled badges"
       options={neutralOptions}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
     />
 
     <AutoCompleteExample
@@ -142,21 +148,21 @@ export const Default = () => (
         ...option,
         variant: 'default'
       }))}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
     />
 
     <AutoCompleteExample
       id="auto-complete-3"
       label="AutoComplete with color badges"
       options={colorOptions}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
     />
 
     <AutoCompleteExample
       id="auto-complete-4"
       label="AutoComplete with subtle color badges"
       options={colorOptions.map((option) => ({ ...option, subtle: true }))}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
     />
 
     <AutoCompleteExample
@@ -167,14 +173,14 @@ export const Default = () => (
         subtle: true,
         variant: 'default'
       }))}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
     />
 
     <AutoCompleteExample
       id="auto-complete-6"
       label="AutoComplete with custom neutral badges"
       options={neutralOptions}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
       components={{
         MultiValue: NeutralMultiValue
       }}
@@ -184,7 +190,7 @@ export const Default = () => (
       id="auto-complete-7"
       label="AutoComplete with read-only badges"
       options={neutralOptions}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
       components={{
         MultiValue: ReadOnlyMultiValue
       }}
@@ -194,7 +200,7 @@ export const Default = () => (
       id="auto-complete-8"
       label="AutoComplete with pill-shaped badges"
       options={neutralOptions}
-      variant={select('Variant', variantOptions, 'default')}
+      {...args}
       components={{
         MultiValue: PillMultiValue
       }}
@@ -202,5 +208,11 @@ export const Default = () => (
   </Box>
 );
 
+Default.args = {
+  hideDropdownIndicator: false,
+  isDisabled: false,
+  isMulti: true,
+  variant: 'default'
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/avatar.stories.js
+++ b/stories/avatar.stories.js
@@ -1,94 +1,86 @@
-import { boolean, select, text } from '@storybook/addon-knobs';
-
 import notes from './avatar.md';
 import { Avatar, Flex, theme } from '../src';
 
 const sizes = Object.keys(theme.avatarSizes);
 
 export default {
-  title: 'Avatar'
+  title: 'Avatar',
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+        options: sizes
+      }
+    }
+  }
 };
 
-export const Default = () => (
-  <Flex justifyContent="space-around" mt="100px">
-    <Avatar
-      name={text('Avatar 1', 'Aruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 2', 'Bruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 3', 'Cruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 4', 'Druce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 5', 'Eruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 6', 'Fruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 7', 'Gruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 8', 'Hruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 9', 'Iruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-    <Avatar
-      name={text('Avatar 10', '+42')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-    />
-  </Flex>
-);
+export const Default = (args) => {
+  const {
+    avatar1,
+    avatar2,
+    avatar3,
+    avatar4,
+    avatar5,
+    avatar6,
+    avatar7,
+    avatar8,
+    avatar9,
+    avatar10,
+    ...rest
+  } = args;
 
+  return (
+    <Flex justifyContent="space-around" mt="100px">
+      <Avatar name={avatar1} {...rest} />
+      <Avatar name={avatar2} {...rest} />
+      <Avatar name={avatar3} {...rest} />
+      <Avatar name={avatar4} {...rest} />
+      <Avatar name={avatar5} {...rest} />
+      <Avatar name={avatar6} {...rest} />
+      <Avatar name={avatar7} {...rest} />
+      <Avatar name={avatar8} {...rest} />
+      <Avatar name={avatar9} {...rest} />
+      <Avatar name={avatar10} {...rest} />
+    </Flex>
+  );
+};
+
+Default.args = {
+  avatar1: 'Aruce Wayne',
+  avatar2: 'Bruce Wayne',
+  avatar3: 'Cruce Wayne',
+  avatar4: 'Druce Wayne',
+  avatar5: 'Eruce Wayne',
+  avatar6: 'Fruce Wayne',
+  avatar7: 'Gruce Wayne',
+  avatar8: 'Hruce Wayne',
+  avatar9: 'Iruce Wayne',
+  avatar10: '+42',
+  size: 'default',
+  subtle: false
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };
 
-export const CustomColor = () => (
-  <Flex justifyContent="space-around" mt="100px">
-    <Avatar
-      name={text('Avatar 1', 'Aruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-      baseColor="monochrome.grey80"
-    />
-    <Avatar
-      name={text('Avatar 2', 'Aruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-      baseColor="monochrome.grey40"
-    />
-    <Avatar
-      name={text('Avatar 3', 'Aruce Wayne')}
-      subtle={boolean('subtle', false)}
-      size={select('Size', sizes, 'default')}
-      baseColor="blue"
-    />
-  </Flex>
-);
+export const CustomColor = (args) => {
+  const { avatar1, avatar2, avatar3, ...rest } = args;
 
+  return (
+    <Flex justifyContent="space-around" mt="100px">
+      <Avatar name={avatar1} {...rest} baseColor="monochrome.grey80" />
+      <Avatar name={avatar2} {...rest} baseColor="monochrome.grey40" />
+      <Avatar name={avatar3} {...rest} baseColor="blue" />
+    </Flex>
+  );
+};
+
+CustomColor.args = {
+  avatar1: 'Aruce Wayne',
+  avatar2: 'Aruce Wayne',
+  avatar3: 'Aruce Wayne',
+  size: 'default',
+  subtle: false
+};
 CustomColor.storyName = 'custom color';
 CustomColor.parameters = { notes: { markdown: notes } };

--- a/stories/avatar.stories.js
+++ b/stories/avatar.stories.js
@@ -64,10 +64,8 @@ export const Default = () => (
   </Flex>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const CustomColor = () => (
   <Flex justifyContent="space-around" mt="100px">
@@ -92,7 +90,5 @@ export const CustomColor = () => (
   </Flex>
 );
 
-CustomColor.story = {
-  name: 'custom color',
-  parameters: { notes: { markdown: notes } }
-};
+CustomColor.storyName = 'custom color';
+CustomColor.parameters = { notes: { markdown: notes } };

--- a/stories/badges.stories.js
+++ b/stories/badges.stories.js
@@ -1,5 +1,3 @@
-import { boolean, select } from '@storybook/addon-knobs';
-
 import notes from './badges.md';
 import { Badge, Box, colors, Flex, Heading, Icon } from '../src';
 
@@ -9,28 +7,27 @@ const iconEnd = <Icon name="cross" />;
 const iconStart = <Icon name="cr-logo" />;
 
 export default {
-  title: 'Badges'
+  title: 'Badges',
+  argTypes: {
+    variant: {
+      name: 'variant',
+      control: {
+        type: 'select',
+        options: variantOptions
+      }
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Badges</Heading.H1>
     <Flex>
-      <Badge
-        mr="regular"
-        subtle={boolean('Subtle', false)}
-        variant={select('Variant', variantOptions)}
-      >
+      <Badge mr="regular" {...args}>
         NEUTRAL
       </Badge>
       {badgeColors.map((color) => (
-        <Badge
-          paletteColor={color}
-          key={color}
-          mr="regular"
-          subtle={boolean('Subtle', false)}
-          variant={select('Variant', variantOptions)}
-        >
+        <Badge paletteColor={color} key={color} mr="regular" {...args}>
           {color.toUpperCase()}
         </Badge>
       ))}
@@ -38,18 +35,14 @@ export const Default = () => (
   </Box>
 );
 
+Default.args = { subtle: false };
 Default.parameters = { notes: { markdown: notes } };
 
-export const IconEnd = () => (
+export const IconEnd = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Badges with ending icon</Heading.H1>
     <Flex>
-      <Badge
-        mr="regular"
-        iconEnd={iconEnd}
-        subtle={boolean('Subtle', false)}
-        variant={select('Variant', variantOptions)}
-      >
+      <Badge mr="regular" iconEnd={iconEnd} {...args}>
         NEUTRAL
       </Badge>
       {badgeColors.map((color) => (
@@ -58,8 +51,7 @@ export const IconEnd = () => (
           key={color}
           mr="regular"
           iconEnd={iconEnd}
-          subtle={boolean('Subtle', false)}
-          variant={select('Variant', variantOptions)}
+          {...args}
         >
           {color.toUpperCase()}
         </Badge>
@@ -68,18 +60,14 @@ export const IconEnd = () => (
   </Box>
 );
 
+IconEnd.args = { subtle: false };
 IconEnd.parameters = { notes: { markdown: notes } };
 
-export const IconStart = () => (
+export const IconStart = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Badges with staring icon</Heading.H1>
     <Flex>
-      <Badge
-        mr="regular"
-        iconStart={iconStart}
-        subtle={boolean('Subtle', false)}
-        variant={select('Variant', variantOptions)}
-      >
+      <Badge mr="regular" iconStart={iconStart} {...args}>
         NEUTRAL
       </Badge>
       {badgeColors.map((color) => (
@@ -88,8 +76,7 @@ export const IconStart = () => (
           key={color}
           mr="regular"
           iconStart={iconStart}
-          subtle={boolean('Subtle', false)}
-          variant={select('Variant', variantOptions)}
+          {...args}
         >
           {color.toUpperCase()}
         </Badge>
@@ -98,19 +85,14 @@ export const IconStart = () => (
   </Box>
 );
 
+IconStart.args = { subtle: false };
 IconStart.parameters = { notes: { markdown: notes } };
 
-export const IconStartIconEnd = () => (
+export const IconStartIconEnd = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Badges with starting and ending icons</Heading.H1>
     <Flex>
-      <Badge
-        mr="regular"
-        iconEnd={iconEnd}
-        iconStart={iconStart}
-        subtle={boolean('Subtle', false)}
-        variant={select('Variant', variantOptions)}
-      >
+      <Badge mr="regular" iconEnd={iconEnd} iconStart={iconStart} {...args}>
         NEUTRAL
       </Badge>
       {badgeColors.map((color) => (
@@ -120,8 +102,7 @@ export const IconStartIconEnd = () => (
           mr="regular"
           iconEnd={iconEnd}
           iconStart={iconStart}
-          subtle={boolean('Subtle', false)}
-          variant={select('Variant', variantOptions)}
+          {...args}
         >
           {color.toUpperCase()}
         </Badge>
@@ -130,5 +111,6 @@ export const IconStartIconEnd = () => (
   </Box>
 );
 
+IconStartIconEnd.args = { subtle: false };
 IconStartIconEnd.storyName = 'Icon Start & Icon End';
 IconStartIconEnd.parameters = { notes: { markdown: notes } };

--- a/stories/badges.stories.js
+++ b/stories/badges.stories.js
@@ -38,9 +38,7 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Default.parameters = { notes: { markdown: notes } };
 
 export const IconEnd = () => (
   <Box as="section" p="regular">
@@ -70,9 +68,7 @@ export const IconEnd = () => (
   </Box>
 );
 
-IconEnd.story = {
-  parameters: { notes: { markdown: notes } }
-};
+IconEnd.parameters = { notes: { markdown: notes } };
 
 export const IconStart = () => (
   <Box as="section" p="regular">
@@ -102,9 +98,7 @@ export const IconStart = () => (
   </Box>
 );
 
-IconStart.story = {
-  parameters: { notes: { markdown: notes } }
-};
+IconStart.parameters = { notes: { markdown: notes } };
 
 export const IconStartIconEnd = () => (
   <Box as="section" p="regular">
@@ -136,7 +130,5 @@ export const IconStartIconEnd = () => (
   </Box>
 );
 
-IconStartIconEnd.story = {
-  name: 'Icon Start & Icon End',
-  parameters: { notes: { markdown: notes } }
-};
+IconStartIconEnd.storyName = 'Icon Start & Icon End';
+IconStartIconEnd.parameters = { notes: { markdown: notes } };

--- a/stories/buttons.stories.js
+++ b/stories/buttons.stories.js
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { boolean, select } from '@storybook/addon-knobs';
 
 import notes from './buttons.md';
 import intent from '../src/theme/colors/intent';
@@ -23,10 +22,32 @@ const icon = <Icon name="lock" />;
 const icon2 = <Icon name="chevron-down" />;
 
 export default {
-  title: 'Buttons'
+  title: 'Buttons',
+  argTypes: {
+    intent: {
+      control: {
+        type: 'select',
+        options: INTENTS
+      }
+    },
+    paletteColor: {
+      name: 'paletteColor',
+      control: {
+        type: 'select',
+        options: PALETTES
+      }
+    },
+    variant: {
+      name: 'variant',
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'minimal']
+      }
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <div style={{ padding: '10px', width: '90%' }}>
     <Heading.H1>Sizes</Heading.H1>
 
@@ -42,55 +63,35 @@ export const Default = () => (
       <div>
         <Heading.H5 as="h2">Small</Heading.H5>
 
-        <Button
-          intent={select('intent', INTENTS, 'brand')}
-          spin={boolean('spin', false)}
-          size="small"
-        >
+        <Button {...args} size="small">
           button label
         </Button>
       </div>
       <div>
         <Heading.H5 as="h2">Medium</Heading.H5>
 
-        <Button
-          intent={select('intent', INTENTS, 'brand')}
-          spin={boolean('spin', false)}
-          size="medium"
-        >
+        <Button {...args} size="medium">
           button label
         </Button>
       </div>
       <div>
         <Heading.H5 as="h2">Large</Heading.H5>
 
-        <Button
-          intent={select('intent', INTENTS, 'brand')}
-          spin={boolean('spin', false)}
-          size="large"
-        >
+        <Button {...args} size="large">
           button label
         </Button>
       </div>
       <div>
         <Heading.H5 as="h2">Jumbo</Heading.H5>
 
-        <Button
-          intent={select('intent', INTENTS, 'brand')}
-          spin={boolean('spin', false)}
-          size="jumbo"
-        >
+        <Button {...args} size="jumbo">
           button label
         </Button>
       </div>
       <div>
         <Heading.H5 as="h2">Responsive Size</Heading.H5>
 
-        <Button
-          intent={select('intent', INTENTS, 'brand')}
-          spin={boolean('spin', false)}
-          size={['small', 'medium', 'large', 'jumbo']}
-        >
+        <Button {...args} size={['small', 'medium', 'large', 'jumbo']}>
           button label
         </Button>
       </div>
@@ -106,90 +107,45 @@ export const Default = () => (
         'repeat(3, 1fr)'
       ]}
     >
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="primary"
-        whiteSpace="nowrap"
-      >
+      <Button {...args} variant="primary" whiteSpace="nowrap">
         primary
       </Button>
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="secondary"
-      >
+      <Button {...args} variant="secondary">
         secondary
       </Button>
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="minimal"
-      >
+      <Button {...args} variant="minimal">
         minimal
       </Button>
 
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="primary"
-        disabled
-      >
+      <Button {...args} variant="primary" disabled>
         primary
       </Button>
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="secondary"
-        disabled
-      >
+      <Button {...args} variant="secondary" disabled>
         secondary
       </Button>
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        variant="minimal"
-        disabled
-      >
+      <Button {...args} variant="minimal" disabled>
         minimal
       </Button>
     </Grid>
 
     <Box width="500px" my="regular">
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        fullWidth
-        variant="primary"
-      >
+      <Button {...args} fullWidth variant="primary">
         full width button
       </Button>
     </Box>
     <Box width="500px" my="regular">
-      <Button
-        intent={select('intent', INTENTS, 'brand')}
-        spin={boolean('spin', false)}
-        fullWidth={[true, true, false]}
-        variant="primary"
-      >
+      <Button {...args} fullWidth={[true, true, false]} variant="primary">
         responsive full width button
       </Button>
     </Box>
   </div>
 );
 
+Default.args = { intent: 'brand', spin: false };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };
 
-const variantOptions = ['primary', 'secondary', 'minimal'];
-
-export const IconButton = () => {
-  const knobs = {
-    intent: select('intent', INTENTS, 'brand'),
-    spin: boolean('spin', false),
-    variant: select('variant', variantOptions),
-    paletteColor: select('palette color', PALETTES, '')
-  };
+export const IconButton = (args) => {
   return (
     <Box m="regular">
       <Box mb="large">
@@ -214,24 +170,19 @@ export const IconButton = () => {
           <tbody>
             <tr className={css({ marginBottom: '10px' })}>
               <td>
-                <Button iconStart={icon} size="small" {...knobs}>
+                <Button iconStart={icon} size="small" {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button size="small" iconEnd={icon2} {...knobs}>
+                <Button size="small" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button
-                  iconStart={icon}
-                  size="small"
-                  iconEnd={icon2}
-                  {...knobs}
-                >
+                <Button iconStart={icon} size="small" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
@@ -240,7 +191,7 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="small"
                   aria-label="Edit"
-                  {...knobs}
+                  {...args}
                 />
               </td>
             </tr>
@@ -251,14 +202,14 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="medium"
                   aria-label="Edit"
-                  {...knobs}
+                  {...args}
                 >
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button size="medium" iconEnd={icon2} {...knobs}>
+                <Button size="medium" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
@@ -268,7 +219,7 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="medium"
                   iconEnd={icon2}
-                  {...knobs}
+                  {...args}
                 >
                   button label
                 </Button>
@@ -279,31 +230,26 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="medium"
                   aria-label="Edit"
-                  {...knobs}
+                  {...args}
                 />
               </td>
             </tr>
 
             <tr className={css({ marginBottom: '10px' })}>
               <td>
-                <Button iconStart={icon} size="large" {...knobs}>
+                <Button iconStart={icon} size="large" {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button size="large" iconEnd={icon2} {...knobs}>
+                <Button size="large" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button
-                  iconStart={icon}
-                  size="large"
-                  iconEnd={icon2}
-                  {...knobs}
-                >
+                <Button iconStart={icon} size="large" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
@@ -313,31 +259,26 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="large"
                   aria-label="Edit"
-                  {...knobs}
+                  {...args}
                 />
               </td>
             </tr>
 
             <tr className={css({ marginBottom: '10px' })}>
               <td>
-                <Button iconStart={icon} size="jumbo" {...knobs}>
+                <Button iconStart={icon} size="jumbo" {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button size="jumbo" iconEnd={icon2} {...knobs}>
+                <Button size="jumbo" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
 
               <td>
-                <Button
-                  iconStart={icon}
-                  size="jumbo"
-                  iconEnd={icon2}
-                  {...knobs}
-                >
+                <Button iconStart={icon} size="jumbo" iconEnd={icon2} {...args}>
                   button label
                 </Button>
               </td>
@@ -347,7 +288,7 @@ export const IconButton = () => {
                   iconStart={icon}
                   size="jumbo"
                   aria-label="Edit"
-                  {...knobs}
+                  {...args}
                 />
               </td>
             </tr>
@@ -359,13 +300,13 @@ export const IconButton = () => {
         <Heading.H2>Full Width</Heading.H2>
 
         <Box mb="regular">
-          <Button iconStart={icon} fullWidth size="jumbo" {...knobs}>
+          <Button iconStart={icon} fullWidth size="jumbo" {...args}>
             button label
           </Button>
         </Box>
 
         <Box mb="regular">
-          <Button fullWidth iconEnd={icon2} size="jumbo" {...knobs}>
+          <Button fullWidth iconEnd={icon2} size="jumbo" {...args}>
             button label
           </Button>
         </Box>
@@ -376,7 +317,7 @@ export const IconButton = () => {
             iconEnd={icon2}
             iconStart={icon}
             size="jumbo"
-            {...knobs}
+            {...args}
           >
             button label
           </Button>
@@ -388,7 +329,7 @@ export const IconButton = () => {
             fullWidth
             iconStart={icon}
             size="jumbo"
-            {...knobs}
+            {...args}
           />
         </Box>
       </Box>
@@ -396,5 +337,6 @@ export const IconButton = () => {
   );
 };
 
+IconButton.args = { intent: 'brand', spin: false, paletteColor: '' };
 IconButton.storyName = 'Icon button';
 IconButton.parameters = { notes: { markdown: notes } };

--- a/stories/buttons.stories.js
+++ b/stories/buttons.stories.js
@@ -178,10 +178,8 @@ export const Default = () => (
   </div>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 const variantOptions = ['primary', 'secondary', 'minimal'];
 
@@ -398,7 +396,5 @@ export const IconButton = () => {
   );
 };
 
-IconButton.story = {
-  name: 'Icon button',
-  parameters: { notes: { markdown: notes } }
-};
+IconButton.storyName = 'Icon button';
+IconButton.parameters = { notes: { markdown: notes } };

--- a/stories/card.stories.js
+++ b/stories/card.stories.js
@@ -82,10 +82,8 @@ export const Default = () => (
   </Grid>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 const exampleCards = [
   {
@@ -203,6 +201,4 @@ export const ShotCardExample = () => (
   </Box>
 );
 
-ShotCardExample.story = {
-  parameters: { notes: { markdown: notes } }
-};
+ShotCardExample.parameters = { notes: { markdown: notes } };

--- a/stories/checkbox.stories.js
+++ b/stories/checkbox.stories.js
@@ -28,10 +28,8 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const WithIcon = () => (
   <Box p="larger">
@@ -73,7 +71,5 @@ export const WithIcon = () => (
   </Box>
 );
 
-WithIcon.story = {
-  name: 'with icon',
-  parameters: { notes: { markdown: notes } }
-};
+WithIcon.storyName = 'with icon';
+WithIcon.parameters = { notes: { markdown: notes } };

--- a/stories/checkbox.stories.js
+++ b/stories/checkbox.stories.js
@@ -1,5 +1,3 @@
-import { text } from '@storybook/addon-knobs';
-
 import notes from './checkbox.md';
 import { Box, Checkbox } from '../src';
 
@@ -31,38 +29,21 @@ export const Default = () => (
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };
 
-export const WithIcon = () => (
+export const WithIcon = (args) => (
   <Box p="larger">
-    <Checkbox icon={text('Icon name', 'download')} label="Checkbox default" />
+    <Checkbox {...args} label="Checkbox default" />
+    <Checkbox {...args} checked label="Checkbox checked" />
+    <Checkbox {...args} disabled label="Checkbox disabled" />
+    <Checkbox {...args} disabled checked label="Checkbox checked disabled" />
+    <Checkbox {...args} indeterminate label="Checkbox indeterminate" />
     <Checkbox
-      icon={text('Icon name', 'download')}
-      checked
-      label="Checkbox checked"
-    />
-    <Checkbox
-      icon={text('Icon name', 'download')}
-      disabled
-      label="Checkbox disabled"
-    />
-    <Checkbox
-      icon={text('Icon name', 'download')}
-      disabled
-      checked
-      label="Checkbox checked disabled"
-    />
-    <Checkbox
-      icon={text('Icon name', 'download')}
-      indeterminate
-      label="Checkbox indeterminate"
-    />
-    <Checkbox
-      icon={text('Icon name', 'download')}
+      {...args}
       checked
       indeterminate
       label="Checkbox checked indeterminate"
     />
     <Checkbox
-      icon={text('Icon name', 'download')}
+      {...args}
       checked
       indeterminate
       disabled
@@ -71,5 +52,6 @@ export const WithIcon = () => (
   </Box>
 );
 
+WithIcon.args = { icon: 'download' };
 WithIcon.storyName = 'with icon';
 WithIcon.parameters = { notes: { markdown: notes } };

--- a/stories/colors.stories.js
+++ b/stories/colors.stories.js
@@ -135,9 +135,7 @@ export const Background = () => (
   />
 );
 
-Background.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Background.parameters = { notes: { markdown: notes } };
 
 export const Border = () => (
   <Swatches
@@ -147,9 +145,7 @@ export const Border = () => (
   />
 );
 
-Border.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Border.parameters = { notes: { markdown: notes } };
 
 export const Icon = () => (
   <Swatches
@@ -159,17 +155,13 @@ export const Icon = () => (
   />
 );
 
-Icon.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Icon.parameters = { notes: { markdown: notes } };
 
 export const Intent = () => (
   <Swatches colorGroup="intent" palette={colors.intent} />
 );
 
-Intent.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Intent.parameters = { notes: { markdown: notes } };
 
 export const Monochrome = () => {
   const { black, white, ...greys } = colors.monochrome;
@@ -177,29 +169,21 @@ export const Monochrome = () => {
   return <Swatches palette={{ black, grey: greys, white }} />;
 };
 
-Monochrome.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Monochrome.parameters = { notes: { markdown: notes } };
 
 export const Palette = () => (
   <Swatches colorGroup="palette" palette={colors.palette} />
 );
 
-Palette.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Palette.parameters = { notes: { markdown: notes } };
 
 export const Primary = () => <Swatches palette={colors.primary} />;
 
-Primary.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Primary.parameters = { notes: { markdown: notes } };
 
 export const Secondary = () => <Swatches palette={colors.secondary} />;
 
-Secondary.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Secondary.parameters = { notes: { markdown: notes } };
 
 export const Text = () => (
   <Swatches
@@ -209,6 +193,4 @@ export const Text = () => (
   />
 );
 
-Text.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Text.parameters = { notes: { markdown: notes } };

--- a/stories/dateTimepicker.stories.js
+++ b/stories/dateTimepicker.stories.js
@@ -48,7 +48,5 @@ class DateTimePickerStories extends Component {
 
 export const Default = () => <DateTimePickerStories />;
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/datepicker.stories.js
+++ b/stories/datepicker.stories.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import { DateUtils } from 'react-day-picker';
-import { date } from '@storybook/addon-knobs';
+import PropTypes from 'prop-types';
 
 import 'react-day-picker/lib/style.css';
 
@@ -44,16 +44,15 @@ class ControlledDatePickers extends Component {
       caption: `Day: ${
         selectedDay ? selectedDay.toLocaleDateString() : 'Not Chosen'
       }`,
-      id: 'sotires-datepicker-input',
       label: 'Choose a Date'
     };
 
+    const { disableDaysBefore: before, disableDaysAfter: after } = this.props;
+    const disabledDays = { before, after };
+
     const SimpleDatePicker = () => (
       <DatePicker
-        disabledDays={{
-          before: new Date(date('Disable Days Before', defaultBefore)),
-          after: new Date(date('Disable Days After', defaultAfter))
-        }}
+        disabledDays={disabledDays}
         onDayClick={this.onDayClick}
         selectedDays={selectedDay}
       />
@@ -69,13 +68,8 @@ class ControlledDatePickers extends Component {
         <Box>
           <Heading.H1 mb="large">DatePickerInput</Heading.H1>
           <DatePickerInput
-            dayPickerProps={{
-              disabledDays: {
-                before: new Date(date('Disable Days Before', defaultBefore)),
-                after: new Date(date('Disable Days After', defaultAfter))
-              }
-            }}
-            inputProps={inputProps}
+            dayPickerProps={{ disabledDays }}
+            inputProps={{ ...inputProps, id: 'stories-datepicker-input-1' }}
             onDayChange={this.onDayChange}
             value={selectedDay}
           />
@@ -86,7 +80,7 @@ class ControlledDatePickers extends Component {
             DatePickerInput with Sibling (z-index check)
           </Heading.H1>
           <DatePickerInput
-            inputProps={inputProps}
+            inputProps={{ ...inputProps, id: 'stories-datepicker-input-2' }}
             onDayChange={this.onDayChange}
             value={selectedDay}
           />
@@ -112,11 +106,32 @@ class ControlledDatePickers extends Component {
   }
 }
 
-export default {
-  title: 'DatePicker'
+ControlledDatePickers.propTypes = {
+  disableDaysBefore: PropTypes.instanceOf(Date).isRequired,
+  disableDaysAfter: PropTypes.instanceOf(Date).isRequired
 };
 
-export const Default = () => <ControlledDatePickers />;
+export default {
+  title: 'DatePicker',
+  argTypes: {
+    disableDaysBefore: {
+      control: {
+        type: 'date'
+      }
+    },
+    disableDaysAfter: {
+      control: {
+        type: 'date'
+      }
+    }
+  }
+};
 
+export const Default = (args) => <ControlledDatePickers {...args} />;
+
+Default.args = {
+  disableDaysBefore: defaultBefore,
+  disableDaysAfter: defaultAfter
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/datepicker.stories.js
+++ b/stories/datepicker.stories.js
@@ -118,7 +118,5 @@ export default {
 
 export const Default = () => <ControlledDatePickers />;
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/descriptionLists.stories.js
+++ b/stories/descriptionLists.stories.js
@@ -61,6 +61,4 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/descriptionLists.stories.js
+++ b/stories/descriptionLists.stories.js
@@ -1,5 +1,3 @@
-import { boolean } from '@storybook/addon-knobs';
-
 import notes from './descriptionLists.md';
 import {
   Box,
@@ -13,11 +11,11 @@ export default {
   title: 'Description Lists'
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Description Lists</Heading.H1>
 
-    <DescriptionList inline={boolean('Inline', false)}>
+    <DescriptionList {...args}>
       <DescriptionTerm>Batman</DescriptionTerm>
       <DescriptionDetails>
         Batman is a fictional superhero appearing in American comic books
@@ -61,4 +59,5 @@ export const Default = () => (
   </Box>
 );
 
+Default.args = { inline: false };
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/dropdowns.stories.js
+++ b/stories/dropdowns.stories.js
@@ -140,10 +140,8 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const CustomTrigger = () => (
   <Box as="section" p="regular">
@@ -156,7 +154,5 @@ export const CustomTrigger = () => (
   </Box>
 );
 
-CustomTrigger.story = {
-  name: 'custom trigger',
-  parameters: { notes: { markdown: notes } }
-};
+CustomTrigger.storyName = 'custom trigger';
+CustomTrigger.parameters = { notes: { markdown: notes } };

--- a/stories/formField.stories.js
+++ b/stories/formField.stories.js
@@ -48,7 +48,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/grid.stories.js
+++ b/stories/grid.stories.js
@@ -21,10 +21,8 @@ export const GridGap = () => {
   );
 };
 
-GridGap.story = {
-  name: 'grid gap',
-  parameters: { notes: { markdown: notes } }
-};
+GridGap.storyName = 'grid gap';
+GridGap.parameters = { notes: { markdown: notes } };
 
 export const GridRow = () => {
   return (
@@ -42,7 +40,5 @@ export const GridRow = () => {
   );
 };
 
-GridRow.story = {
-  name: 'grid row',
-  parameters: { notes: { markdown: notes } }
-};
+GridRow.storyName = 'grid row';
+GridRow.parameters = { notes: { markdown: notes } };

--- a/stories/header.stories.js
+++ b/stories/header.stories.js
@@ -41,7 +41,5 @@ export const Default = () => {
   );
 };
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/header.stories.js
+++ b/stories/header.stories.js
@@ -1,5 +1,3 @@
-import { select, text } from '@storybook/addon-knobs';
-
 import notes from './header.md';
 import { Button, Grid, Heading, Header } from '../src';
 
@@ -19,20 +17,33 @@ const buttonOptions = {
 };
 
 export default {
-  title: 'Header'
+  title: 'Header',
+  argTypes: {
+    buttonCount: {
+      control: {
+        type: 'select',
+        options: buttonOptions
+      }
+    },
+    headingTag: {
+      control: {
+        type: 'select',
+        options: headingOptions
+      }
+    }
+  }
 };
 
-export const Default = () => {
-  const DynamicHeading = Heading[select('Heading Tag', headingOptions, 'H1')];
-  const buttonCount = select('Button Count', buttonOptions, 2);
+export const Default = (args) => {
+  const { buttonCount, headingTag, headingText } = args;
+
+  const DynamicHeading = Heading[headingTag];
 
   return (
     <Grid gridGap="large">
       <section>
         <Header>
-          <DynamicHeading mb="0">
-            {text('Heading Text', 'Section Header')}
-          </DynamicHeading>
+          <DynamicHeading mb="0">{headingText}</DynamicHeading>
           {buttonCount > 1 && <Button variant="secondary">Secondary</Button>}
           {buttonCount > 0 && <Button variant="primary">Primary</Button>}
         </Header>
@@ -41,5 +52,10 @@ export const Default = () => {
   );
 };
 
+Default.args = {
+  buttonCount: 2,
+  headingTag: 'H1',
+  headingText: 'Section Header'
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/headings.stories.js
+++ b/stories/headings.stories.js
@@ -16,7 +16,5 @@ export const Default = () => (
   </>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/icons.stories.js
+++ b/stories/icons.stories.js
@@ -1,5 +1,3 @@
-import { select } from '@storybook/addon-knobs';
-
 import notes from './icons.md';
 import { Box, Grid, Icon, Text } from '../src';
 
@@ -40,10 +38,18 @@ const rotationOptions = {
 };
 
 export default {
-  title: 'Icons'
+  title: 'Icons',
+  argTypes: {
+    rotation: {
+      control: {
+        type: 'select',
+        options: rotationOptions
+      }
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Grid
     gridTemplateColumns={`repeat(${AVAILABLE_ICONS.length}, 1fr)`}
     gridGap="large"
@@ -54,17 +60,13 @@ export const Default = () => (
   >
     {AVAILABLE_ICONS.map((icon) => (
       <Box key={icon} textAlign="center">
-        <Icon
-          name={icon}
-          color="grey100"
-          fontSize="38px"
-          rotation={select('Rotation', rotationOptions, null)}
-        />
+        <Icon name={icon} color="grey100" fontSize="38px" {...args} />
         <Text variant="tiny">{icon}</Text>
       </Box>
     ))}
   </Grid>
 );
 
+Default.args = { rotation: null };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/icons.stories.js
+++ b/stories/icons.stories.js
@@ -66,7 +66,5 @@ export const Default = () => (
   </Grid>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -109,7 +109,5 @@ export const Default = () => (
   </form>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/links.stories.js
+++ b/stories/links.stories.js
@@ -45,7 +45,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/masonry.stories.js
+++ b/stories/masonry.stories.js
@@ -44,7 +44,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/masonry.stories.js
+++ b/stories/masonry.stories.js
@@ -1,7 +1,6 @@
 import random from 'lodash/random';
 import shuffle from 'lodash/shuffle';
 import { readableColor } from 'polished';
-import { text } from '@storybook/addon-knobs';
 
 import notes from './masonry.md';
 import { colors, Box, Flex, Masonry, Text } from '../src';
@@ -16,17 +15,9 @@ export default {
   title: 'Masonry'
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box height="100%" p="regular" width="100%">
-    <Masonry
-      columnCount={text('Column Count', '5')}
-      columnGap={text('Column Gap', 'regular')}
-      columnRuleColor={text('Column Rule Color', '')}
-      columnRuleStyle={text('Column Rule Style', '')}
-      columnRuleWidth={text('Column Rule Width', '')}
-      columnWidth={text('Column Width', '300px')}
-      rowGap={text('Row Gap', 'regular')}
-    >
+    <Masonry {...args}>
       {boxColors.map((color, key) => (
         <Flex
           alignItems="center"
@@ -44,5 +35,14 @@ export const Default = () => (
   </Box>
 );
 
+Default.args = {
+  columnCount: '5',
+  columnGap: 'regular',
+  columnRuleColor: '',
+  columnRuleStyle: '',
+  columnRuleWidth: '',
+  columnWidth: '300px',
+  rowGap: 'regular'
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/menu.stories.js
+++ b/stories/menu.stories.js
@@ -155,10 +155,8 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const CustomMenuItems = () => (
   <Box as="section" p="regular">
@@ -171,7 +169,5 @@ export const CustomMenuItems = () => (
   </Box>
 );
 
-CustomMenuItems.story = {
-  name: 'custom menu items',
-  parameters: { notes: { markdown: notes } }
-};
+CustomMenuItems.storyName = 'custom menu items';
+CustomMenuItems.parameters = { notes: { markdown: notes } };

--- a/stories/menuItem.stories.js
+++ b/stories/menuItem.stories.js
@@ -20,7 +20,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/menuItem.stories.js
+++ b/stories/menuItem.stories.js
@@ -1,5 +1,3 @@
-import { boolean } from '@storybook/addon-knobs';
-
 import notes from './menuItem.md';
 import { Box, Heading, MenuItem, Text } from '../src';
 
@@ -7,18 +5,15 @@ export default {
   title: 'MenuItem'
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1 mb="regular">Menu Item</Heading.H1>
-    <MenuItem
-      isDisabled={boolean('isDisabled', false)}
-      isFocused={boolean('isFocused', false)}
-      isSelected={boolean('isSelected', false)}
-    >
+    <MenuItem {...args}>
       <Text color="inherit">I am a Menu Item in a Text Component!</Text>
     </MenuItem>
   </Box>
 );
 
+Default.args = { isDisabled: false, isFocused: false, isSelected: false };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/modal.stories.js
+++ b/stories/modal.stories.js
@@ -1,7 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
-import { number, text } from '@storybook/addon-knobs';
 
 import notes from './modal.md';
 import { Box, Button, Card, Grid, Heading, Icon, Modal } from '../src';
@@ -106,32 +105,28 @@ export default {
   title: 'Modal'
 };
 
-export const Default = () => (
-  <ModalStory
-    p="large"
-    numberOfLines={number('Lines of Content', 100)}
-    height={text('Height', 'calc(100% - 40px)')}
-    width={text('Modal Width', '500px')}
-  >
+export const Default = (args) => (
+  <ModalStory p="large" {...args}>
     Foo
   </ModalStory>
 );
 
+Default.args = {
+  height: 'calc(100% - 40px)',
+  numberOfLines: 100,
+  width: '500px'
+};
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };
 
-export const ScrollingPage = () => (
+export const ScrollingPage = (args) => (
   <Box height="3000px">
-    <ModalStory
-      p="large"
-      numberOfLines={number('Lines of Content', 100)}
-      height={text('Height', '300px')}
-      width={text('Modal Width', '500px')}
-    >
+    <ModalStory p="large" {...args}>
       Bar
     </ModalStory>
   </Box>
 );
 
+ScrollingPage.args = { height: '300px', numberOfLines: 100, width: '500px' };
 ScrollingPage.storyName = 'scrolling page';
 ScrollingPage.parameters = { notes: { markdown: notes } };

--- a/stories/modal.stories.js
+++ b/stories/modal.stories.js
@@ -117,10 +117,8 @@ export const Default = () => (
   </ModalStory>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const ScrollingPage = () => (
   <Box height="3000px">
@@ -135,7 +133,5 @@ export const ScrollingPage = () => (
   </Box>
 );
 
-ScrollingPage.story = {
-  name: 'scrolling page',
-  parameters: { notes: { markdown: notes } }
-};
+ScrollingPage.storyName = 'scrolling page';
+ScrollingPage.parameters = { notes: { markdown: notes } };

--- a/stories/paginations.stories.js
+++ b/stories/paginations.stories.js
@@ -48,10 +48,8 @@ export const Default = () => (
   </Flex>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };
 
 export const Small = () => (
   <Flex mt="100px" justifyContent="center">
@@ -59,10 +57,8 @@ export const Small = () => (
   </Flex>
 );
 
-Small.story = {
-  name: 'small',
-  parameters: { notes: { markdown: notes } }
-};
+Small.storyName = 'small';
+Small.parameters = { notes: { markdown: notes } };
 
 export const Medium = () => (
   <Flex mt="100px" justifyContent="center">
@@ -70,7 +66,5 @@ export const Medium = () => (
   </Flex>
 );
 
-Medium.story = {
-  name: 'medium',
-  parameters: { notes: { markdown: notes } }
-};
+Medium.storyName = 'medium';
+Medium.parameters = { notes: { markdown: notes } };

--- a/stories/pane.stories.js
+++ b/stories/pane.stories.js
@@ -61,7 +61,5 @@ export const Default = () => (
   </Grid>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/paragraph.stories.js
+++ b/stories/paragraph.stories.js
@@ -13,7 +13,5 @@ export const Default = () => (
   </>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/popovers.stories.js
+++ b/stories/popovers.stories.js
@@ -42,7 +42,5 @@ export const Default = () => (
   </Flex>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/progressBar.stories.js
+++ b/stories/progressBar.stories.js
@@ -28,7 +28,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/progressBar.stories.js
+++ b/stories/progressBar.stories.js
@@ -1,4 +1,3 @@
-import { number, select, boolean } from '@storybook/addon-knobs';
 import notes from './progressBar.md';
 import { Box, ProgressBar } from '../src';
 
@@ -11,22 +10,26 @@ const AVAILABLE_ICONS = {
 };
 
 export default {
-  title: 'ProgressBar'
+  title: 'ProgressBar',
+  argTypes: {
+    iconEndName: {
+      control: {
+        type: 'select',
+        options: AVAILABLE_ICONS
+      }
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box m="regular" id="skip" maxWidth="750px">
     <ProgressBar percentage={96} />
     <ProgressBar percentage={66.67} iconEndName="lock" />
     <ProgressBar mt="large" width="50%" percentage={25} showPercentage />
-    <ProgressBar
-      mt="large"
-      percentage={number('percentage', 33)}
-      showPercentage={boolean('showPercentage', false)}
-      iconEndName={select('iconEndName', AVAILABLE_ICONS, null)}
-    />
+    <ProgressBar mt="large" {...args} />
   </Box>
 );
 
+Default.args = { percentage: 33, showPercentage: false, iconEndName: null };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/radioButton.stories.js
+++ b/stories/radioButton.stories.js
@@ -38,7 +38,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/radioButtonGroup.stories.js
+++ b/stories/radioButtonGroup.stories.js
@@ -51,7 +51,5 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/radioButtonGroup.stories.js
+++ b/stories/radioButtonGroup.stories.js
@@ -1,4 +1,3 @@
-import { boolean } from '@storybook/addon-knobs';
 import notes from './radioButtonGroup.md';
 import { Box, Flex, RadioButtonGroup } from '../src';
 
@@ -27,16 +26,21 @@ const groupOptions = [
 ];
 
 export default {
-  title: 'RadioButtonGroup'
+  title: 'RadioButtonGroup',
+  argTypes: {
+    disabled: {
+      name: 'disabled (group level)'
+    }
+  }
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box p="larger">
     <RadioButtonGroup
       options={groupOptions}
       name="grouped"
       onChange={onChange}
-      disabled={boolean('Disabled (Group level)', false)}
+      {...args}
     />
 
     <Flex flexDirection="row">
@@ -44,12 +48,13 @@ export const Default = () => (
         options={groupOptions}
         name="grouped-across"
         onChange={onChange}
-        disabled={boolean('Disabled (Group level)', false)}
+        {...args}
         buttonProps={{ mr: 'small' }}
       />
     </Flex>
   </Box>
 );
 
+Default.args = { disabled: false };
 Default.storyName = 'default';
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/select.stories.js
+++ b/stories/select.stories.js
@@ -65,7 +65,5 @@ export const Default = () => (
   </form>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/spinners.stories.js
+++ b/stories/spinners.stories.js
@@ -1,5 +1,3 @@
-import { boolean, number, text } from '@storybook/addon-knobs';
-
 import notes from './spinners.md';
 import { Box, Heading, Spinner } from '../src';
 
@@ -7,22 +5,22 @@ export default {
   title: 'Spinners'
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Spinners</Heading.H1>
 
-    <Spinner
-      color={text('color', 'monochrome.black')}
-      left={text('left', '50%')}
-      opacity={number('opacity', 0.25)}
-      position={text('position', 'absolute')}
-      top={text('top', '50%')}
-      diameter={['20px', '40px', '80px', '100px']}
-      spin={boolean('spin', true)}
-    >
+    <Spinner {...args} diameter={['20px', '40px', '80px', '100px']}>
       I Loaded!
     </Spinner>
   </Box>
 );
 
+Default.args = {
+  color: 'monochrome.black',
+  left: '50%',
+  opacity: 0.25,
+  position: 'absolute',
+  spin: true,
+  top: '50%'
+};
 Default.parameters = { notes: { markdown: notes } };

--- a/stories/spinners.stories.js
+++ b/stories/spinners.stories.js
@@ -25,6 +25,4 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/tabs.stories.js
+++ b/stories/tabs.stories.js
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { boolean } from '@storybook/addon-knobs';
 
 import notes from './tabs.md';
 import { Box, Heading, Icon, Tab, Tabs } from '../src';
@@ -22,11 +21,11 @@ export default {
   title: 'Tabs'
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <Box as="section" p="regular">
     <Heading.H1>Tabs</Heading.H1>
 
-    <Tabs defaultTabId="tab-2" tabBarAside={boolean('aside', false) && aside}>
+    <Tabs defaultTabId="tab-2" tabBarAside={args.aside && aside}>
       {null /* see if we can handle null */}
       <Tab id="tab-1" title="Tab 1">
         <Box bg="palette.blue.lighter" p="largest">
@@ -60,6 +59,7 @@ export const Default = () => (
   </Box>
 );
 
+Default.args = { aside: false };
 Default.parameters = { notes: { markdown: notes } };
 
 export const Controlled = () => {

--- a/stories/tabs.stories.js
+++ b/stories/tabs.stories.js
@@ -60,9 +60,7 @@ export const Default = () => (
   </Box>
 );
 
-Default.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Default.parameters = { notes: { markdown: notes } };
 
 export const Controlled = () => {
   const [activeTabId, setActiveTabId] = useState('tab-1');
@@ -117,6 +115,4 @@ export const Controlled = () => {
   );
 };
 
-Controlled.story = {
-  parameters: { notes: { markdown: notes } }
-};
+Controlled.parameters = { notes: { markdown: notes } };

--- a/stories/text.stories.js
+++ b/stories/text.stories.js
@@ -9,7 +9,5 @@ export const Default = () => (
   <Text>The quick brown fox jumps over the lazy dog</Text>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/textarea.stories.js
+++ b/stories/textarea.stories.js
@@ -85,7 +85,5 @@ export const Default = () => (
   </form>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/toast.stories.js
+++ b/stories/toast.stories.js
@@ -38,7 +38,5 @@ export const Default = () => {
   );
 };
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/stories/tooltip.stories.js
+++ b/stories/tooltip.stories.js
@@ -83,7 +83,5 @@ export const Default = () => (
   </Grid>
 );
 
-Default.story = {
-  name: 'default',
-  parameters: { notes: { markdown: notes } }
-};
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.5.5":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.5.5":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
   integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
@@ -45,7 +45,29 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.8.tgz#5b783b9808f15cef71547f1b691f34f8ff6003a6"
   integrity sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==
 
-"@babel/core@>=7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.13.10", "@babel/core@^7.7.5":
+"@babel/core@7.12.9":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
+  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.7"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.9"
+    "@babel/types" "^7.12.7"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@>=7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.12.1", "@babel/core@^7.12.3", "@babel/core@^7.13.10", "@babel/core@^7.7.5":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.10.tgz#07de050bbd8193fcd8a3c27918c0890613a94559"
   integrity sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
@@ -67,7 +89,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.4.0":
+"@babel/generator@^7.12.1", "@babel/generator@^7.12.5", "@babel/generator@^7.13.0", "@babel/generator@^7.13.9", "@babel/generator@^7.4.0":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
   integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
@@ -165,34 +187,33 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/helper-member-expression-to-functions@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz#6aa4bb678e0f8c22f58cdb79451d30494461b091"
-  integrity sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==
+"@babel/helper-member-expression-to-functions@^7.13.0", "@babel/helper-member-expression-to-functions@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
+  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
   dependencies:
-    "@babel/types" "^7.13.0"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.7.0":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
-  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12", "@babel/helper-module-imports@^7.7.0":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-transforms@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz#42eb4bd8eea68bab46751212c357bfed8b40f6f1"
-  integrity sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.13.0":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz#600e58350490828d82282631a1422268e982ba96"
+  integrity sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==
   dependencies:
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-replace-supers" "^7.13.0"
-    "@babel/helper-simple-access" "^7.12.13"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-replace-supers" "^7.13.12"
+    "@babel/helper-simple-access" "^7.13.12"
     "@babel/helper-split-export-declaration" "^7.12.13"
     "@babel/helper-validator-identifier" "^7.12.11"
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.0"
-    lodash "^4.17.19"
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
@@ -200,6 +221,11 @@
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-plugin-utils@7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
+  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.13.0"
@@ -215,22 +241,22 @@
     "@babel/helper-wrap-function" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz#6034b7b51943094cb41627848cb219cb02be1d24"
-  integrity sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==
+"@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.0", "@babel/helper-replace-supers@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz#6442f4c1ad912502481a564a7386de0c77ff3804"
+  integrity sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.13.0"
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
     "@babel/helper-optimise-call-expression" "^7.12.13"
     "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.0"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-simple-access@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz#8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4"
-  integrity sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
+"@babel/helper-simple-access@^7.12.13", "@babel/helper-simple-access@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz#dd6c538afb61819d205a012c31792a39c7a5eaf6"
+  integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -266,7 +292,7 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/helpers@^7.13.10":
+"@babel/helpers@^7.12.5", "@babel/helpers@^7.13.10":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8"
   integrity sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
@@ -284,10 +310,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.8.3":
-  version "7.13.11"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
-  integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.8.3":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.12.tgz#ba320059420774394d3b0c0233ba40e4250b81d1"
+  integrity sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.13.8":
   version "7.13.8"
@@ -370,6 +396,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
+"@babel/plugin-proposal-object-rest-spread@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz#def9bd03cea0f9b72283dac0ec22d289c7691069"
+  integrity sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-transform-parameters" "^7.12.1"
 
 "@babel/plugin-proposal-object-rest-spread@^7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.13.8":
   version "7.13.8"
@@ -485,6 +520,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-jsx@7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
+  integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-syntax-jsx@^7.12.1", "@babel/plugin-syntax-jsx@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz#044fb81ebad6698fe62c478875575bcbb9b70f15"
@@ -513,7 +555,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@7.8.3", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -753,16 +795,16 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.12.12"
 
-"@babel/plugin-transform-react-jsx@^7.12.12", "@babel/plugin-transform-react-jsx@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.13.tgz#6c9f993b9f6fb6f0e32a4821ed59349748576a3e"
-  integrity sha512-hhXZMYR8t9RvduN2uW4sjl6MRtUhzNE726JvoJhpjhxKgRUVkZqTsA0xc49ALZxQM7H26pZ/lLvB2Yrea9dllA==
+"@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.12.12", "@babel/plugin-transform-react-jsx@^7.12.13":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz#1df5dfaf0f4b784b43e96da6f28d630e775f68b3"
+  integrity sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-jsx" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
 "@babel/plugin-transform-react-pure-annotations@^7.12.1":
   version "7.12.1"
@@ -985,7 +1027,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.12.13", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
+"@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
   integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
@@ -994,7 +1036,7 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.0.tgz#6d95752475f86ee7ded06536de309a65fc8966cc"
   integrity sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
@@ -1009,14 +1051,19 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.13.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
-  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.12.tgz#edbf99208ef48852acdff1c8a681a1e4ade580cd"
+  integrity sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
+
+"@base2/pretty-print-object@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
+  integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1494,7 +1541,7 @@
     source-map "^0.6.1"
     write-file-atomic "2.4.1"
 
-"@jest/transform@^26.6.2":
+"@jest/transform@^26.0.0", "@jest/transform@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.6.2.tgz#5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b"
   integrity sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==
@@ -1534,6 +1581,50 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@mdx-js/loader@^1.6.19":
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"
+  integrity sha512-9CjGwy595NaxAYp0hF9B/A0lH6C8Rms97e2JS9d3jVUtILn6pT5i5IV965ra3lIWc7Rs1GG1tBdVF7dCowYe6Q==
+  dependencies:
+    "@mdx-js/mdx" "1.6.22"
+    "@mdx-js/react" "1.6.22"
+    loader-utils "2.0.0"
+
+"@mdx-js/mdx@1.6.22", "@mdx-js/mdx@^1.6.19":
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
+  integrity sha512-AMxuLxPz2j5/6TpF/XSdKpQP1NlG0z11dFOlq+2IP/lSgl11GY8ji6S/rgsViN/L0BDvHvUMruRb7ub+24LUYA==
+  dependencies:
+    "@babel/core" "7.12.9"
+    "@babel/plugin-syntax-jsx" "7.12.1"
+    "@babel/plugin-syntax-object-rest-spread" "7.8.3"
+    "@mdx-js/util" "1.6.22"
+    babel-plugin-apply-mdx-type-prop "1.6.22"
+    babel-plugin-extract-import-names "1.6.22"
+    camelcase-css "2.0.1"
+    detab "2.0.4"
+    hast-util-raw "6.0.1"
+    lodash.uniq "4.5.0"
+    mdast-util-to-hast "10.0.1"
+    remark-footnotes "2.0.0"
+    remark-mdx "1.6.22"
+    remark-parse "8.0.3"
+    remark-squeeze-paragraphs "4.0.0"
+    style-to-object "0.3.0"
+    unified "9.2.0"
+    unist-builder "2.0.3"
+    unist-util-visit "2.0.3"
+
+"@mdx-js/react@1.6.22", "@mdx-js/react@^1.6.19":
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.22.tgz#ae09b4744fddc74714ee9f9d6f17a66e77c43573"
+  integrity sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==
+
+"@mdx-js/util@1.6.22":
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
+  integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1656,6 +1747,125 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-actions@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.1.21.tgz#881dceb0ed650fe28086d9993703f8081b29f4ce"
+  integrity sha512-H+nhSgK3X5L+JfArsC9ufvgJzQwPN9UXBxhMl74faEDCo9RGmq9ywNcjn9XlZGGnJ3jCaYrI/T1u0J7F6PBrTA==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-api" "6.1.21"
+    "@storybook/components" "6.1.21"
+    "@storybook/core-events" "6.1.21"
+    "@storybook/theming" "6.1.21"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    polished "^3.4.4"
+    prop-types "^15.7.2"
+    react-inspector "^5.0.1"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+    uuid "^8.0.0"
+
+"@storybook/addon-backgrounds@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-6.1.21.tgz#ada6c0a8a375855f99da0a7de770dd2c245d536d"
+  integrity sha512-4kJB6UcrqOo8fjm1BnfEOvw8ysPSfzIn2j5Q7h3WzoQF0VbU62+EQLTznluFfMjJ1I2FMCTz8YcwDOZn1FNlig==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-logger" "6.1.21"
+    "@storybook/components" "6.1.21"
+    "@storybook/core-events" "6.1.21"
+    "@storybook/theming" "6.1.21"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/addon-controls@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.1.21.tgz#14e3473cfa6dcdb88e57a74e1a42b57bd87c69ee"
+  integrity sha512-IJgZWD2E9eLKj8DJLA9lT63N4jPfVneFJ05gnPco01ZJCEiDAo7babP5Ns2UTJDUaQEtX0m04UoIkidcteWKsA==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-api" "6.1.21"
+    "@storybook/components" "6.1.21"
+    "@storybook/node-logger" "6.1.21"
+    "@storybook/theming" "6.1.21"
+    core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+
+"@storybook/addon-docs@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.1.21.tgz#2ab12698200e7353c4789d705b0a1972f6d268d8"
+  integrity sha512-MvTmxrOSo+zZ5MaMx9LVWM8DlvVHeryCJKPJx8BYCEN38r8mIK7uCFYok8oMPmACrVe0MfXOdJCm1HKkBKjsMg==
+  dependencies:
+    "@babel/core" "^7.12.1"
+    "@babel/generator" "^7.12.1"
+    "@babel/parser" "^7.12.3"
+    "@babel/plugin-transform-react-jsx" "^7.12.1"
+    "@babel/preset-env" "^7.12.1"
+    "@jest/transform" "^26.0.0"
+    "@mdx-js/loader" "^1.6.19"
+    "@mdx-js/mdx" "^1.6.19"
+    "@mdx-js/react" "^1.6.19"
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-api" "6.1.21"
+    "@storybook/client-logger" "6.1.21"
+    "@storybook/components" "6.1.21"
+    "@storybook/core" "6.1.21"
+    "@storybook/core-events" "6.1.21"
+    "@storybook/csf" "0.0.1"
+    "@storybook/node-logger" "6.1.21"
+    "@storybook/postinstall" "6.1.21"
+    "@storybook/source-loader" "6.1.21"
+    "@storybook/theming" "6.1.21"
+    acorn "^7.1.0"
+    acorn-jsx "^5.1.0"
+    acorn-walk "^7.0.0"
+    core-js "^3.0.1"
+    doctrine "^3.0.0"
+    escodegen "^1.12.0"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    html-tags "^3.1.0"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.15"
+    prettier "~2.0.5"
+    prop-types "^15.7.2"
+    react-element-to-jsx-string "^14.3.1"
+    regenerator-runtime "^0.13.7"
+    remark-external-links "^6.0.0"
+    remark-slug "^6.0.0"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/addon-essentials@^6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.1.21.tgz#ed528fbdebbc841459a8264f74e517c04b0e1a27"
+  integrity sha512-kdQ/hnfwwodWVFvMdvSbhOyLv/cUJyhgVRyIamrURP9I0OlWhpOAHhwMjAT2KKceutN3UjNpSCqFNSL4dMu25g==
+  dependencies:
+    "@storybook/addon-actions" "6.1.21"
+    "@storybook/addon-backgrounds" "6.1.21"
+    "@storybook/addon-controls" "6.1.21"
+    "@storybook/addon-docs" "6.1.21"
+    "@storybook/addon-toolbars" "6.1.21"
+    "@storybook/addon-viewport" "6.1.21"
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/node-logger" "6.1.21"
+    core-js "^3.0.1"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-knobs@^6.1.21":
   version "6.1.21"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-6.1.21.tgz#3b732baca4195a525629705264cd6f23ec7afe8d"
@@ -1717,6 +1927,34 @@
     memoizerific "^1.11.3"
     prop-types "^15.7.2"
     util-deprecate "^1.0.2"
+
+"@storybook/addon-toolbars@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.1.21.tgz#7e03ef74fe448c5b4e378cb08e1d79b9d8496d9f"
+  integrity sha512-89NtiqLT3ltb7Jb7rAug7jnWIDh6SxXa9i3mOoKEIcvuRJEmxGLF1Z79A+zXOJOKBUEEUgfJCtVS2lixakgwKA==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-api" "6.1.21"
+    "@storybook/components" "6.1.21"
+    core-js "^3.0.1"
+
+"@storybook/addon-viewport@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.1.21.tgz#893090cca12f55abb4d8acade5f04e58e6317b1f"
+  integrity sha512-FrQk0BXCI4HdbBn9+8b+Cp2HvsweZkgW/joKfcF2vVLoasUBB4bl+9uU3HV/3a08glgjPl24caDMPgoRKS90WQ==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/api" "6.1.21"
+    "@storybook/client-logger" "6.1.21"
+    "@storybook/components" "6.1.21"
+    "@storybook/core-events" "6.1.21"
+    "@storybook/theming" "6.1.21"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.13.7"
 
 "@storybook/addons@5.3.21":
   version "5.3.21"
@@ -2058,6 +2296,13 @@
     npmlog "^4.1.2"
     pretty-hrtime "^1.0.3"
 
+"@storybook/postinstall@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.1.21.tgz#a7598b53291e3ab74400feb492359cc0d725d9a3"
+  integrity sha512-mg3fNqdQYiz6ivQIU1WMKqtqrFt5GySmsPCar3Y+xOdMClmpx6pZYcpiN782h8CIFA1XnldGR3TKVtWP848qOg==
+  dependencies:
+    core-js "^3.0.1"
+
 "@storybook/react@^6.1.21":
   version "6.1.21"
   resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.1.21.tgz#1c4d01dba8d8f130f9b7da4038a380eeb9c61f38"
@@ -2119,6 +2364,23 @@
   dependencies:
     core-js "^3.6.5"
     find-up "^4.1.0"
+
+"@storybook/source-loader@6.1.21":
+  version "6.1.21"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.1.21.tgz#23cda170dd77d188df52cb3f2ab8ef191e04b8a0"
+  integrity sha512-eMbmQG3a/7SFxVN+KGJKfk4uxLqQz2Nk95zvHyRvoX15LRyMnFvmdvmULe5vwRev8Npd4AS0EZ37m3jAEcD0ig==
+  dependencies:
+    "@storybook/addons" "6.1.21"
+    "@storybook/client-logger" "6.1.21"
+    "@storybook/csf" "0.0.1"
+    core-js "^3.0.1"
+    estraverse "^4.2.0"
+    global "^4.3.2"
+    loader-utils "^2.0.0"
+    lodash "^4.17.15"
+    prettier "~2.0.5"
+    regenerator-runtime "^0.13.7"
+    source-map "^0.7.3"
 
 "@storybook/storybook-deployer@^2.8.7":
   version "2.8.7"
@@ -2510,6 +2772,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/parse5@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
+  integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
+
 "@types/prettier@^2.0.0":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.5.tgz#b6ab3bba29e16b821d84e09ecfaded462b816b00"
@@ -2596,7 +2863,7 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
@@ -2892,7 +3159,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.1.0, acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
@@ -2902,7 +3169,7 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn-walk@^7.1.1:
+acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
@@ -2917,7 +3184,7 @@ acorn@^6.0.1, acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3429,6 +3696,14 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
+babel-plugin-apply-mdx-type-prop@1.6.22:
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.22.tgz#d216e8fd0de91de3f1478ef3231e05446bc8705b"
+  integrity sha512-VefL+8o+F/DfK24lPZMtJctrCVOfgbqLAGZSkxwhazQv4VxPg3Za/i40fu22KR2m8eEda+IfSOlPLUSIiLcnCQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "7.10.4"
+    "@mdx-js/util" "1.6.22"
+
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
@@ -3451,6 +3726,13 @@ babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.27:
     escape-string-regexp "^1.0.5"
     find-root "^1.1.0"
     source-map "^0.5.7"
+
+babel-plugin-extract-import-names@1.6.22:
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.22.tgz#de5f9a28eb12f3eb2578bf74472204e66d1a13dc"
+  integrity sha512-yJ9BsJaISua7d8zNT7oRG1ZLBJCIdZ4PZqmH8qa9N5AK01ifk3fnkc98AXhtzE7UkfCsEumvoQWgoYLhOnJ7jQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "7.10.4"
 
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
@@ -4115,6 +4397,11 @@ camel-case@^4.1.1:
     pascal-case "^3.1.1"
     tslib "^1.10.0"
 
+camelcase-css@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
+  integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
+
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -4160,6 +4447,11 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+ccount@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
+  integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -4390,6 +4682,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -5009,6 +5306,13 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detab@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detab/-/detab-2.0.4.tgz#b927892069aff405fbb9a186fe97a44a92a94b43"
+  integrity sha512-8zdsQA5bIkoRECvCrNKPla84lyoR7DSAyf7p0YgXzBO9PDJx8KntPUay7NS6yp+KdxdVtiE5SpHKtbp2ZQyA9g==
+  dependencies:
+    repeat-string "^1.5.4"
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -5290,6 +5594,11 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+"emoji-regex@>=6.0.0 <=6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
+  integrity sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -5549,7 +5858,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@^1.14.1, escodegen@^1.9.1:
+escodegen@^1.12.0, escodegen@^1.14.1, escodegen@^1.9.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -6411,7 +6720,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -6480,6 +6789,13 @@ git-url-parse@^11.1.2:
   integrity sha512-i3XNa8IKmqnUqWBcdWBjOcnyZYfN3C1WRvnKI6ouFWwsXCZEnlgbwbm55ZpJ3OJMhfEP/ryFhqW8bBhej3C5Ug==
   dependencies:
     git-up "^4.0.0"
+
+github-slugger@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
+  integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
+  dependencies:
+    emoji-regex ">=6.0.0 <=6.1.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -6770,10 +7086,62 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hast-to-hyperscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-9.0.1.tgz#9b67fd188e4c81e8ad66f803855334173920218d"
+  integrity sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==
+  dependencies:
+    "@types/unist" "^2.0.3"
+    comma-separated-tokens "^1.0.0"
+    property-information "^5.3.0"
+    space-separated-tokens "^1.0.0"
+    style-to-object "^0.3.0"
+    unist-util-is "^4.0.0"
+    web-namespaces "^1.0.0"
+
+hast-util-from-parse5@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz#554e34abdeea25ac76f5bd950a1f0180e0b3bc2a"
+  integrity sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==
+  dependencies:
+    "@types/parse5" "^5.0.0"
+    hastscript "^6.0.0"
+    property-information "^5.0.0"
+    vfile "^4.0.0"
+    vfile-location "^3.2.0"
+    web-namespaces "^1.0.0"
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz#60c99d0b519e12ab4ed32e58f150ec3f61ed1974"
   integrity sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA==
+
+hast-util-raw@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-6.0.1.tgz#973b15930b7529a7b66984c98148b46526885977"
+  integrity sha512-ZMuiYA+UF7BXBtsTBNcLBF5HzXzkyE6MLzJnL605LKE8GJylNjGc4jjxazAHUtcwT5/CEt6afRKViYB4X66dig==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    hast-util-from-parse5 "^6.0.0"
+    hast-util-to-parse5 "^6.0.0"
+    html-void-elements "^1.0.0"
+    parse5 "^6.0.0"
+    unist-util-position "^3.0.0"
+    vfile "^4.0.0"
+    web-namespaces "^1.0.0"
+    xtend "^4.0.0"
+    zwitch "^1.0.0"
+
+hast-util-to-parse5@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz#1ec44650b631d72952066cea9b1445df699f8479"
+  integrity sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==
+  dependencies:
+    hast-to-hyperscript "^9.0.0"
+    property-information "^5.0.0"
+    web-namespaces "^1.0.0"
+    xtend "^4.0.0"
+    zwitch "^1.0.0"
 
 hastscript@^5.0.0:
   version "5.1.2"
@@ -6892,6 +7260,11 @@ html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+
+html-void-elements@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
+  integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
 html-webpack-plugin@^4.2.1:
   version "4.5.0"
@@ -7094,7 +7467,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7113,6 +7486,11 @@ ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 inquirer@^7.0.0:
   version "7.3.3"
@@ -7174,6 +7552,11 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-absolute-url@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
+  integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -7188,7 +7571,7 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-alphabetical@^1.0.0:
+is-alphabetical@1.0.4, is-alphabetical@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
   integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
@@ -7311,6 +7694,14 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
+is-dom@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
+  integrity sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==
+  dependencies:
+    is-object "^1.0.1"
+    is-window "^1.0.2"
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -7418,6 +7809,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
+
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
@@ -7427,6 +7823,11 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-plain-object@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
+  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -7501,10 +7902,25 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+  integrity sha1-LIlspT25feRdPDMTOmXYyfVjSA0=
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -8119,6 +8535,11 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+js-string-escape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
+  integrity sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8567,6 +8988,11 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
+lodash.uniq@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
 lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -8677,6 +9103,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
 markdown-to-jsx@^6.10.3, markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -8704,6 +9135,27 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdast-squeeze-paragraphs@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz#7c4c114679c3bee27ef10b58e2e015be79f1ef97"
+  integrity sha512-zxdPn69hkQ1rm4J+2Cs2j6wDEv7O17TfXTJ33tl/+JPIoEmtV9t2ZzBM5LPHE8QlHsmVD8t3vPKCyY3oH+H8MQ==
+  dependencies:
+    unist-util-remove "^2.0.0"
+
+mdast-util-definitions@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-2.0.1.tgz#2c931d8665a96670639f17f98e32c3afcfee25f3"
+  integrity sha512-Co+DQ6oZlUzvUR7JCpP249PcexxygiaKk9axJh+eRzHDZJk2julbIdKB4PXHVxdBuLzvJ1Izb+YDpj2deGMOuA==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
+mdast-util-definitions@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz#c5c1a84db799173b4dcf7643cda999e440c24db2"
+  integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
 mdast-util-from-markdown@^0.8.0:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.2.tgz#d9b5c4eae245e742de8542b9a9fe642c400e8f42"
@@ -8713,6 +9165,20 @@ mdast-util-from-markdown@^0.8.0:
     mdast-util-to-string "^2.0.0"
     micromark "~2.10.0"
     parse-entities "^2.0.0"
+
+mdast-util-to-hast@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
+  integrity sha512-BW3LM9SEMnjf4HXXVApZMt8gLQWVNXc3jryK0nJu/rOXPOnlkUjmdkDlmxMirpbU9ILncGFIwLH/ubnWBbcdgA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-definitions "^4.0.0"
+    mdurl "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
 
 mdast-util-to-markdown@^0.5.0:
   version "0.5.4"
@@ -8726,10 +9192,20 @@ mdast-util-to-markdown@^0.5.0:
     repeat-string "^1.0.0"
     zwitch "^1.0.0"
 
+mdast-util-to-string@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
+  integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
+
+mdurl@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -9705,6 +10181,11 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
+parse5@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -10073,6 +10554,11 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
+prettier@~2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-error@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.2.tgz#be89f82d81b1c86ec8fdfbc385045882727f93b6"
@@ -10179,7 +10665,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10188,7 +10674,7 @@ prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-property-information@^5.0.0:
+property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
   integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
@@ -10473,6 +10959,14 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+react-element-to-jsx-string@^14.3.1:
+  version "14.3.2"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.2.tgz#c0000ed54d1f8b4371731b669613f2d4e0f63d5c"
+  integrity sha512-WZbvG72cjLXAxV7VOuSzuHEaI3RHj10DZu8EcKQpkKcAj7+qAkG5XUeSdX5FXrA0vPrlx0QsnAzZEBJwzV0e+w==
+  dependencies:
+    "@base2/pretty-print-object" "1.0.0"
+    is-plain-object "3.0.1"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
@@ -10519,6 +11013,15 @@ react-input-autosize@^3.0.0:
   integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
+
+react-inspector@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.0.tgz#45a325e15f33e595be5356ca2d3ceffb7d6b8c3a"
+  integrity sha512-JAwswiengIcxi4X/Ssb8nf6suOuQsyit8Fxo04+iPKTnPNY3XIOuagjMZSzpJDDKkYcc/ARlySOYZZv626WUvA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    is-dom "^1.0.0"
+    prop-types "^15.0.0"
 
 react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -10945,12 +11448,80 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-external-links@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/remark-external-links/-/remark-external-links-6.1.0.tgz#1a545b3cf896eae00ec1732d90f595f75a329abe"
+  integrity sha512-dJr+vhe3wuh1+E9jltQ+efRMqtMDOOnfFkhtoArOmhnBcPQX6THttXMkc/H0kdnAvkXTk7f2QdOYm5qo/sGqdw==
+  dependencies:
+    extend "^3.0.0"
+    is-absolute-url "^3.0.0"
+    mdast-util-definitions "^2.0.0"
+    space-separated-tokens "^1.0.0"
+    unist-util-visit "^2.0.0"
+
+remark-footnotes@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-2.0.0.tgz#9001c4c2ffebba55695d2dd80ffb8b82f7e6303f"
+  integrity sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==
+
+remark-mdx@1.6.22:
+  version "1.6.22"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.6.22.tgz#06a8dab07dcfdd57f3373af7f86bd0e992108bbd"
+  integrity sha512-phMHBJgeV76uyFkH4rvzCftLfKCr2RZuF+/gmVcaKrpsihyzmhXjA0BEMDaPTXG5y8qZOKPVo83NAOX01LPnOQ==
+  dependencies:
+    "@babel/core" "7.12.9"
+    "@babel/helper-plugin-utils" "7.10.4"
+    "@babel/plugin-proposal-object-rest-spread" "7.12.1"
+    "@babel/plugin-syntax-jsx" "7.12.1"
+    "@mdx-js/util" "1.6.22"
+    is-alphabetical "1.0.4"
+    remark-parse "8.0.3"
+    unified "9.2.0"
+
+remark-parse@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
+  integrity sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==
+  dependencies:
+    ccount "^1.0.0"
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^2.0.0"
+    vfile-location "^3.0.0"
+    xtend "^4.0.1"
+
 remark-parse@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
   integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
     mdast-util-from-markdown "^0.8.0"
+
+remark-slug@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-6.0.0.tgz#2b54a14a7b50407a5e462ac2f376022cce263e2c"
+  integrity sha512-ln67v5BrGKHpETnm6z6adlJPhESFJwfuZZ3jrmi+lKTzeZxh2tzFzUfDD4Pm2hRGOarHLuGToO86MNMZ/hA67Q==
+  dependencies:
+    github-slugger "^1.0.0"
+    mdast-util-to-string "^1.0.0"
+    unist-util-visit "^2.0.0"
+
+remark-squeeze-paragraphs@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-4.0.0.tgz#76eb0e085295131c84748c8e43810159c5653ead"
+  integrity sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==
+  dependencies:
+    mdast-squeeze-paragraphs "^4.0.0"
 
 remark-stringify@^9.0.0:
   version "9.0.0"
@@ -10989,7 +11560,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.0.0, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -11088,7 +11659,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -11660,6 +12231,11 @@ stackframe@^1.1.1:
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -11897,6 +12473,13 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
+
+style-to-object@0.3.0, style-to-object@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
+  integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
+  dependencies:
+    inline-style-parser "0.1.1"
 
 style-value-types@4.1.1:
   version "4.1.1"
@@ -12336,6 +12919,16 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
+  integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
 trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
@@ -12479,6 +13072,14 @@ unfetch@^4.1.0:
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
   integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -12502,7 +13103,7 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
-unified@^9.1.0:
+unified@9.2.0, unified@^9.1.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
   integrity sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==
@@ -12543,6 +13144,11 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unist-builder@2.0.3, unist-builder@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
+  integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
+
 unist-util-find-all-after@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz#fdfecd14c5b7aea5e9ef38d5e0d5f774eeb561f6"
@@ -12550,10 +13156,34 @@ unist-util-find-all-after@^3.0.2:
   dependencies:
     unist-util-is "^4.0.0"
 
+unist-util-generated@^1.0.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
+  integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
+
 unist-util-is@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.2.tgz#c7d1341188aa9ce5b3cff538958de9895f14a5de"
   integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
+
+unist-util-position@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
+  integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
+
+unist-util-remove-position@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz#5d19ca79fdba712301999b2b73553ca8f3b352cc"
+  integrity sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
+unist-util-remove@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-2.0.1.tgz#fa13c424ff8e964f3aa20d1098b9a690c6bfaa39"
+  integrity sha512-YtuetK6o16CMfG+0u4nndsWpujgsHDHHLyE0yGpJLLn5xSjKeyGyzEBOI2XbmoUHCYabmNgX52uxlWoQhcvR7Q==
+  dependencies:
+    unist-util-is "^4.0.0"
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
@@ -12561,6 +13191,23 @@ unist-util-stringify-position@^2.0.0:
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+unist-util-visit-parents@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"
+  integrity sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^4.0.0"
+
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
+  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
 
 universalify@^1.0.0:
   version "1.0.0"
@@ -12708,10 +13355,10 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+uuid@^8.0.0, uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.2.0"
@@ -12748,6 +13395,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^3.0.0, vfile-location@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.2.0.tgz#d8e41fbcbd406063669ebf6c33d56ae8721d0f3c"
+  integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==
 
 vfile-message@^2.0.0:
   version "2.0.4"
@@ -12818,6 +13470,11 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+web-namespaces@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
+  integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -13063,7 +13720,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,7 +1020,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.12.18"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.18.tgz#af137bd7e7d9705a412b3caaf991fe6aaa97831b"
   integrity sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==
@@ -1096,7 +1096,7 @@
     source-map "^0.5.7"
     stylis "^4.0.3"
 
-"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+"@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1117,7 +1117,7 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "^4.0.3"
 
-"@emotion/core@^10.0.20", "@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
+"@emotion/core@^10.0.20", "@emotion/core@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -1137,7 +1137,7 @@
     "@emotion/memoize" "^0.7.4"
     stylis "^4.0.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1865,31 +1865,6 @@
     core-js "^3.0.1"
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
-
-"@storybook/addon-knobs@^6.1.21":
-  version "6.1.21"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-6.1.21.tgz#3b732baca4195a525629705264cd6f23ec7afe8d"
-  integrity sha512-VARcSRNcvjISwxveN2o3tZUnbFzA7fLLqVBvixN0wvvbzhHtNtmQgfAhUzq43Uyd2joRcxiV2YXLeJ5VHh4BoQ==
-  dependencies:
-    "@storybook/addons" "6.1.21"
-    "@storybook/api" "6.1.21"
-    "@storybook/channels" "6.1.21"
-    "@storybook/client-api" "6.1.21"
-    "@storybook/components" "6.1.21"
-    "@storybook/core-events" "6.1.21"
-    "@storybook/theming" "6.1.21"
-    copy-to-clipboard "^3.0.8"
-    core-js "^3.0.1"
-    escape-html "^1.0.3"
-    fast-deep-equal "^3.1.1"
-    global "^4.3.2"
-    lodash "^4.17.15"
-    prop-types "^15.7.2"
-    qs "^6.6.0"
-    react-color "^2.17.0"
-    react-lifecycles-compat "^3.0.4"
-    react-select "^3.0.8"
-    regenerator-runtime "^0.13.7"
 
 "@storybook/addon-links@^6.1.21":
   version "6.1.21"
@@ -5838,7 +5813,7 @@ escalade@^3.0.2, escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -11099,20 +11074,6 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
-
-react-select@^3.0.8:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"
-  integrity sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^3.0.0"
-    react-transition-group "^4.3.0"
 
 react-select@^4.2.1:
   version "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,24 +1866,6 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-links@^6.1.21":
-  version "6.1.21"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.1.21.tgz#59b04c4a0bd1c8dc86fecea64a2531154df382e6"
-  integrity sha512-DFPK6aYs9VIs1tO0PJ+mBwg64ZLv6NcVwFJ083ghCj/hR+0+3NRox+oRHXCWq7RHtnJeU4VKEiRx2EpE9L9Bkg==
-  dependencies:
-    "@storybook/addons" "6.1.21"
-    "@storybook/client-logger" "6.1.21"
-    "@storybook/core-events" "6.1.21"
-    "@storybook/csf" "0.0.1"
-    "@storybook/router" "6.1.21"
-    "@types/qs" "^6.9.0"
-    core-js "^3.0.1"
-    global "^4.3.2"
-    prop-types "^15.7.2"
-    qs "^6.6.0"
-    regenerator-runtime "^0.13.7"
-    ts-dedent "^2.0.0"
-
 "@storybook/addon-notes@^5.3.21":
   version "5.3.21"
   resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-5.3.21.tgz#1382e322c1027e8fb681c48bcbf4d73ca89d132a"


### PR DESCRIPTION
This adds `addon-essentials` and converts our stories from `addon-knobs` to `addon-controls`, as this is the path forward.  `addon-docs` is disabled for this PR due to some rendering issues preventing migration from `addon-notes` yet.   (`addon-notes` is deprecated, and `addon-knobs` is slated to be deprecated soon.)

`addon-essentials` also gives us a few other recommended addons including `actions`, `backgrounds`, `toolbars`, and `viewport`, some of which work out of the box and some of which will require at least minimal configuration to be useful.

This also removes `addon-links` since we're not using it.