### PR TITLE
Allow 'bg' as prop for <Button>

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -110,7 +110,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  bg: '',
+  bg: null,
   children: undefined,
   disabled: false,
   fullWidth: false,

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import { propType } from '@styled-system/prop-types';
 
 import ButtonContent from './ButtonContent';
 import ButtonSpinner from './ButtonSpinner';
@@ -40,6 +41,8 @@ const Button = forwardRef(
 );
 
 Button.propTypes = {
+  bg: propType,
+
   /**
    * Content to render inside the button.
    */
@@ -107,6 +110,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
+  bg: '',
   children: undefined,
   disabled: false,
   fullWidth: false,

--- a/src/Button/StyledButton.js
+++ b/src/Button/StyledButton.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {
   borders,
   borderColor,
+  color,
   display,
   fontWeight,
   fontSize,
@@ -72,12 +73,14 @@ const StyledButton = styled.button`
   ${whiteSpace};
   ${borders};
   ${borderColor};
+  ${color};
   ${display};
 `;
 
 StyledButton.propTypes = {
   ...borders.propTypes,
   ...borderColor.propTypes,
+  ...color.propTypes,
   ...fontWeight.propTypes,
   ...fontSize.propTypes,
   ...lineHeight.propTypes,

--- a/stories/buttons.stories.js
+++ b/stories/buttons.stories.js
@@ -138,6 +138,30 @@ export const Default = (args) => (
         responsive full width button
       </Button>
     </Box>
+
+    <Heading.H1>Custom Colors</Heading.H1>
+
+    <Grid
+      gridGap="10px 138px"
+      gridTemplateColumns={[
+        'repeat(1, 0fr)',
+        'repeat(1, 0fr)',
+        'repeat(4, 1fr)'
+      ]}
+    >
+      <Button {...args} variant="primary" bg="teal">
+        primary w/ teal background
+      </Button>
+      <Button {...args} variant="primary" paletteColor="yellow">
+        primary w/ yellow color
+      </Button>
+      <Button {...args} variant="secondary" bg="palette.blue.lighter">
+        secondary w/ lighter blue background
+      </Button>
+      <Button {...args} variant="secondary" bg="red">
+        secondary w/ red color
+      </Button>
+    </Grid>
   </div>
 );
 


### PR DESCRIPTION
<img width="1424" alt="Screen Shot 2021-04-27 at 12 25 47 PM" src="https://user-images.githubusercontent.com/6894325/116300403-b70ae200-a753-11eb-9b3c-18be4e67e048.png">


All other buttons still look the same:
<img width="1400" alt="Screen Shot 2021-04-29 at 8 44 52 AM" src="https://user-images.githubusercontent.com/6894325/116579416-3836b600-a8c7-11eb-90c0-11d1a28d4237.png">
