### PR TITLE
Export ToastOptions type

### DIFF
--- a/src/Toast/toast.tsx
+++ b/src/Toast/toast.tsx
@@ -29,4 +29,5 @@ const toast = INTENTS.reduce(
   {} as Record<Intent, ToastFunction>
 );
 
+export { ToastOptions };
 export default toast;


### PR DESCRIPTION
Export `ToastOptions` so it can be used in the main app.

I'm refactoring `toast.jsx` in the main app, but I want to use the `ToastOptions` type.