### PR TITLE
Export ModalProps

### DIFF
--- a/dist/Modal/Modal.d.ts
+++ b/dist/Modal/Modal.d.ts
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import ReactModal from 'react-modal';
 import { Theme } from '@emotion/react';
 import { Css } from './buildModalCss';
-declare type Props = ReactModal.Props & {
+export declare type Props = ReactModal.Props & {
     modalCss?: Css;
     overlayCss?: Css;
     theme: Theme;

--- a/dist/Modal/index.d.ts
+++ b/dist/Modal/index.d.ts
@@ -1,1 +1,1 @@
-export { default } from './Modal';
+export { default, Props as ModalProps } from './Modal';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -29,7 +29,7 @@ export { default as Link } from './Link';
 export { default as Masonry, MasonryItem, MasonryContainer } from './Masonry';
 export { default as Menu } from './Menu';
 export { default as MenuItem } from './MenuItem';
-export { default as Modal } from './Modal';
+export { default as Modal, ModalProps } from './Modal';
 export { default as Pagination } from './Pagination';
 export { default as Pane } from './Pane';
 export { default as Paragraph } from './Paragraph';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.100.3",
+  "version": "0.100.4",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { Global, Theme, withTheme } from '@emotion/react';
 
 import buildModalCss, { Css } from './buildModalCss';
 
-type Props = ReactModal.Props & {
+export type Props = ReactModal.Props & {
   modalCss?: Css;
   overlayCss?: Css;
   theme: Theme;

--- a/src/Modal/index.ts
+++ b/src/Modal/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Modal';
+export { default, Props as ModalProps } from './Modal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export { default as Link } from './Link';
 export { default as Masonry, MasonryItem, MasonryContainer } from './Masonry';
 export { default as Menu } from './Menu';
 export { default as MenuItem } from './MenuItem';
-export { default as Modal } from './Modal';
+export { default as Modal, ModalProps } from './Modal';
 export { default as Pagination } from './Pagination';
 export { default as Pane } from './Pane';
 export { default as Paragraph } from './Paragraph';


### PR DESCRIPTION
This is useful for typing `Modal`'s props in the monolith.