### PR TITLE
Add @emotion/jest to types in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "lib": ["dom", "es2017"],
     "noEmit": true,
     "outDir": "dist",
-    "types": ["jest", "jest-enzyme", "jest-plugin-context"]
+    "types": ["@emotion/jest", "jest", "jest-enzyme", "jest-plugin-context"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
We have seen both green and red CI builds since converting a file with
`toHaveStyleRule` to TS, so there seems to be an intermittent issue.

This change is intended to ensure that the `toHaveStyleRule` declaration
is consistently discovered.