### PR TITLE
Ted/tooltip header inherit color

### DIFF
--- a/dist/Tooltip/Tooltip.js
+++ b/dist/Tooltip/Tooltip.js
@@ -47,7 +47,7 @@ const Tooltip = (_a) => {
     };
     const renderTooltip = (attrs) => ((0, jsx_runtime_1.jsx)(Box_1.default, Object.assign({ as: framer_motion_1.motion.div, initial: "hidden", variants: variants, animate: mounted ? 'visible' : 'hidden', transition: springConfig }, attrs, { children: (0, jsx_runtime_1.jsxs)(Card_1.default, Object.assign({ bg: "monochrome.grey90", borderRadius: "small", boxShadow: "elevation1", color: "monochrome.white", gridGap: "smallest", fontSize: "size3", maxWidth: "200px", p: "smaller", css: (0, react_2.css) `
           word-break: break-word;
-        ` }, props, { children: [title && (0, jsx_runtime_1.jsx)(Heading_1.default.H3, Object.assign({ mb: "0" }, { children: title }), void 0), content && ((0, jsx_runtime_1.jsx)(Text_1.default, Object.assign({ as: Grid_1.default, fontSize: "inherit", color: "inherit", textAlign: "inherit" }, { children: content }), void 0))] }), void 0) }), void 0));
+        ` }, props, { children: [title && ((0, jsx_runtime_1.jsx)(Heading_1.default.H3, Object.assign({ color: "inherit", mb: "0" }, { children: title }), void 0)), content && ((0, jsx_runtime_1.jsx)(Text_1.default, Object.assign({ as: Grid_1.default, fontSize: "inherit", color: "inherit", textAlign: "inherit" }, { children: content }), void 0))] }), void 0) }), void 0));
     return ((0, jsx_runtime_1.jsx)(headless_1.default, Object.assign({ render: (attrs) => (mounted ? renderTooltip(attrs) : ''), offset: [0, 4], plugins: [tippy_js_1.sticky, lazyPlugin], popperOptions: {
             modifiers: [
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catchandrelease/arbor",
-  "version": "0.110.1",
+  "version": "0.110.2",
   "description": "React component library for Catch&Release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -68,7 +68,11 @@ const Tooltip: VFC<Props> = ({ children, content, title, ...props }) => {
         `}
         {...props}
       >
-        {title && <Heading.H3 mb="0">{title}</Heading.H3>}
+        {title && (
+          <Heading.H3 color="inherit" mb="0">
+            {title}
+          </Heading.H3>
+        )}
         {content && (
           <Text
             as={Grid}


### PR DESCRIPTION
Allow the header to inherit the color, so we don't get this:

<img width="309" alt="Screen Shot 2022-03-09 at 10 06 08 AM" src="https://user-images.githubusercontent.com/6894325/157364962-ac0b807d-c60e-45a8-8a6e-818014d708d5.png">

I scanned the C&R repo and the only other place that makes use of the Tooltip header is this one which wouldn't be affected by this change:

<img width="368" alt="Screen Shot 2022-03-09 at 9 53 27 AM" src="https://user-images.githubusercontent.com/6894325/157365017-002a2ba7-8a89-4965-97a1-988d6bb15778.png">